### PR TITLE
fix(memory): Prevent README.md files from being indexed as constitutional memories

### DIFF
--- a/.opencode/skill/system-spec-kit/CHANGELOG.md
+++ b/.opencode/skill/system-spec-kit/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the system-spec-kit skill will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-01-16
+
+*Environment version: 1.0.4.1*
+
+Bug fix for constitutional README indexing issue.
+
+### Fixed
+
+- Constitutional indexer now skips `README.md` files (case-insensitive) in `find_constitutional_files()` to prevent documentation from being indexed as memories
+- `is_memory_file()` validator now excludes README.md files from constitutional directories during `memory_save` operations
+
 ## [1.8.0] - 2026-01-15
 
 *Environment version: 1.0.4.0*

--- a/.opencode/skill/system-spec-kit/mcp_server/handlers/memory-index.js
+++ b/.opencode/skill/system-spec-kit/mcp_server/handlers/memory-index.js
@@ -81,6 +81,8 @@ function find_constitutional_files(workspace_path) {
         const files = fs.readdirSync(constitutional_dir, { withFileTypes: true });
         for (const file of files) {
           if (file.isFile() && file.name.endsWith('.md')) {
+            // Ignore README files (case-insensitive) to prevent indexing documentation
+            if (file.name.toLowerCase() === 'readme.md') continue;
             results.push(path.join(constitutional_dir, file.name));
           }
         }

--- a/.opencode/skill/system-spec-kit/mcp_server/lib/memory-parser.js
+++ b/.opencode/skill/system-spec-kit/mcp_server/lib/memory-parser.js
@@ -272,7 +272,8 @@ function is_memory_file(file_path) {
   const is_constitutional = (
     normalized_path.endsWith('.md') &&
     normalized_path.includes('/.opencode/skill/') &&
-    normalized_path.includes('/constitutional/')
+    normalized_path.includes('/constitutional/') &&
+    !normalized_path.toLowerCase().endsWith('readme.md')
   );
   
   return is_specs_memory || is_constitutional;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Public Release: https://github.com/MichelKerkmeester/opencode-dev-environment
 
 ---
 
+## [**1.0.4.1**] - 2026-01-16
+
+Fixes a bug where README.md files in the constitutional directory were incorrectly indexed as memories. The documentation file's example YAML frontmatter was parsed as real metadata, creating ghost memory entries.
+
+---
+
+**Fixed**
+1. Constitutional indexer now skips `README.md` files (case-insensitive) in `find_constitutional_files()` to prevent documentation from being indexed as memories.
+2. `is_memory_file()` validator now excludes README.md files from constitutional directories during `memory_save` operations.
+
+---
+
+**Upgrade**
+No action required. Pull latest to get the fix. Any previously indexed README memories can be removed with `memory_delete({ id: <id> })`.
+
+**Full Changelog**: [v1.0.4.0...v1.0.4.1](https://github.com/MichelKerkmeester/opencode-dev-environment/compare/v1.0.4.0...v1.0.4.1)
+
+---
+
 ## [**1.0.4.0**] - 2026-01-15
 
 A major quality and architecture release focusing on system reliability, memory system optimization, and codebase maintainability. This version addresses 231 identified issues across the Spec Kit infrastructure, introduces targeted memory retrieval via the Anchor System (achieving 61-93% token savings), modularizes the core MCP server from 2,703 to 319 lines, and upgrades to Voyage 4 embeddings.


### PR DESCRIPTION
## Summary

Fixes a bug where README.md files in the constitutional directory were incorrectly indexed as memories. The documentation file's example YAML frontmatter was parsed as real metadata, creating ghost memory entries (e.g., memory #174 titled "MY RULE TITLE").

## Changes

- **memory-index.js**: `find_constitutional_files()` now skips files named `README.md` (case-insensitive)
- **memory-parser.js**: `is_memory_file()` validator now excludes README.md files from constitutional directories

## Files Modified

| File | Change |
|------|--------|
| `mcp_server/handlers/memory-index.js` | Added README.md skip (2 lines) |
| `mcp_server/lib/memory-parser.js` | Added README.md exclusion (1 line) |
| `CHANGELOG.md` | Added v1.0.4.1 entry |
| `.opencode/skill/system-spec-kit/CHANGELOG.md` | Added v1.8.1 entry |

## Testing

- Verified `memory_index_scan()` no longer picks up README.md
- Verified `memory_save()` rejects README.md file paths
- Deleted ghost memory #174 from index

## Version

Release: **v1.0.4.1** (patch)