### PR TITLE
fix: Level-specific template path references in YAML configs

### DIFF
--- a/.opencode/command/create/assets/create_skill.yaml
+++ b/.opencode/command/create/assets/create_skill.yaml
@@ -302,8 +302,9 @@ workflow:
     - Initialize spec.md with skill creation context
     - Create plan.md with approach
     templates:
-    - .opencode/skill/system-spec-kit/templates/spec.md
-    - .opencode/skill/system-spec-kit/templates/plan.md
+    # Use Level 2 templates as default for skill creation
+    - .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    - .opencode/skill/system-spec-kit/templates/level_2/plan.md
     outputs:
     - spec.md: created_with_context
     - plan.md: created_with_approach

--- a/.opencode/command/spec_kit/assets/spec_kit_complete_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_complete_auto.yaml
@@ -201,22 +201,50 @@ documentation_levels:
     default: "Level 1 for simple tasks, escalate based on analysis"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  plan: .opencode/skill/system-spec-kit/templates/plan.md
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Optional (any level)
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_1/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_2/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3+/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -707,7 +735,7 @@ workflow:
     - location: "[SPEC_FOLDER]/spec.md"
     optional_documents:
     - decision-record-[name].md: "Architecture Decision Records"
-    template: .opencode/skill/system-spec-kit/templates/spec.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/spec.md  # Use level from available_templates based on complexity
     deep_analysis:
       focus: comprehensive_specification
       approach: rigorous_requirements_definition
@@ -776,7 +804,7 @@ workflow:
     - verified_items_count: "X/Y items verified"
     - p0_status: "all_complete or blocked"
     - deferred_items: list_of_deferred_p2_items
-    template: .opencode/skill/system-spec-kit/templates/checklist.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/checklist.md  # Use level from available_templates based on complexity
     deep_analysis:
       focus: quality_validation_preparation
       approach: comprehensive_checklist_design
@@ -918,9 +946,9 @@ workflow:
     - decision-record.md: "Architecture Decision Records (required at Level 3)"
     decision_records:
       when: significant_technical_decision_needs_documentation
-      template: .opencode/skill/system-spec-kit/templates/decision-record.md
+      template: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md  # Level 3+ only
       note: "Document architecture decisions with full context"
-    template: .opencode/skill/system-spec-kit/templates/plan.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/plan.md  # Use level from available_templates based on complexity
 
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:
@@ -1007,7 +1035,7 @@ workflow:
     - task_phases: defined
     - dependencies: mapped
     - parallel_markers: assigned
-    template: .opencode/skill/system-spec-kit/templates/tasks.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/tasks.md  # Use level from available_templates based on complexity
     deep_analysis:
       focus: implementation_task_design
       approach: systematic_breakdown

--- a/.opencode/command/spec_kit/assets/spec_kit_complete_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_complete_confirm.yaml
@@ -211,22 +211,50 @@ documentation_levels:
     default: "Level 1 for simple tasks, escalate based on analysis"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  plan: .opencode/skill/system-spec-kit/templates/plan.md
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Optional (any level)
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_1/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_2/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3+/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -657,7 +685,7 @@ workflow:
     - Define success criteria
     outputs:
     - spec.md: acceptance_criteria
-    template: .opencode/skill/system-spec-kit/templates/spec.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/spec.md  # Use level from available_templates based on complexity
 
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:
@@ -744,7 +772,7 @@ workflow:
     - verified_items_count: "X/Y items verified"
     - p0_status: "all_complete or blocked"
     - deferred_items: list_of_deferred_p2_items
-    template: .opencode/skill/system-spec-kit/templates/checklist.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/checklist.md  # Use level from available_templates based on complexity
     validation: checklist_verified_and_marked
     checkpoint:
       question: "Step 5 Complete: Checklist verified. How would you like to proceed?"
@@ -873,7 +901,7 @@ workflow:
     outputs:
     - plan.md: technical_approach
     - research.md: resolved_unknowns
-    template: .opencode/skill/system-spec-kit/templates/plan.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/plan.md  # Use level from available_templates based on complexity
 
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:
@@ -947,7 +975,7 @@ workflow:
     - Create tasks.md (required at all levels)
     outputs:
     - tasks.md: implementation_breakdown
-    template: .opencode/skill/system-spec-kit/templates/tasks.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/tasks.md  # Use level from available_templates based on complexity
     validation: tasks_documented
     checkpoint:
       question: "Step 7 Complete: Tasks broken down. Review tasks.md?"

--- a/.opencode/command/spec_kit/assets/spec_kit_implement_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_implement_auto.yaml
@@ -142,16 +142,39 @@ prerequisites:
   note: This workflow assumes planning completed via /spec_kit:plan
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -374,7 +397,7 @@ workflow:
     - Create/validate tasks.md (required at all levels)
     outputs:
     - tasks.md: implementation_breakdown
-    template: .opencode/skill/system-spec-kit/templates/tasks.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/tasks.md  # Use level from available_templates based on complexity
     validation: tasks_documented
 
   step_3_analysis:

--- a/.opencode/command/spec_kit/assets/spec_kit_implement_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_implement_confirm.yaml
@@ -142,16 +142,39 @@ prerequisites:
   note: This workflow assumes planning completed via /spec_kit:plan
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -407,7 +430,7 @@ workflow:
     - Create/validate tasks.md (required at all levels)
     outputs:
     - tasks.md: implementation_breakdown
-    template: .opencode/skill/system-spec-kit/templates/tasks.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/tasks.md  # Use level from available_templates based on complexity
     validation: tasks_documented
     checkpoint:
       question: "Step 2 Complete: Tasks defined. Review tasks.md?"

--- a/.opencode/command/spec_kit/assets/spec_kit_plan_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_plan_auto.yaml
@@ -105,22 +105,50 @@ documentation_levels:
     default: "Level 1 for simple tasks, escalate based on analysis"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  plan: .opencode/skill/system-spec-kit/templates/plan.md
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Optional (any level)
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_1/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_2/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3+/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -417,7 +445,7 @@ workflow:
     - Define success criteria
     outputs:
     - spec.md: acceptance_criteria
-    template: .opencode/skill/system-spec-kit/templates/spec.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/spec.md  # Use level from available_templates based on complexity
     
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:
@@ -586,7 +614,7 @@ workflow:
     outputs:
     - plan.md: technical_approach
     - research.md: resolved_unknowns
-    template: .opencode/skill/system-spec-kit/templates/plan.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/plan.md  # Use level from available_templates based on complexity
     
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:

--- a/.opencode/command/spec_kit/assets/spec_kit_plan_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_plan_confirm.yaml
@@ -105,22 +105,50 @@ documentation_levels:
     default: "Level 1 for simple tasks, escalate based on analysis"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Level 1+ (Baseline - required at all levels)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  plan: .opencode/skill/system-spec-kit/templates/plan.md
-  tasks: .opencode/skill/system-spec-kit/templates/tasks.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Optional (any level)
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_1/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_1/tasks.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_1/implementation-summary.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_2/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_2/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_2/implementation-summary.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3/implementation-summary.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    plan: .opencode/skill/system-spec-kit/templates/level_3+/plan.md
+    tasks: .opencode/skill/system-spec-kit/templates/level_3+/tasks.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+    implementation_summary: .opencode/skill/system-spec-kit/templates/level_3+/implementation-summary.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -444,7 +472,7 @@ workflow:
     - Define success criteria
     outputs:
     - spec.md: acceptance_criteria
-    template: .opencode/skill/system-spec-kit/templates/spec.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/spec.md  # Use level from available_templates based on complexity
     
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:
@@ -627,7 +655,7 @@ workflow:
     outputs:
     - plan.md: technical_approach
     - research.md: resolved_unknowns
-    template: .opencode/skill/system-spec-kit/templates/plan.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/plan.md  # Use level from available_templates based on complexity
     
     # CONFIDENCE CHECKPOINT
     confidence_checkpoint:

--- a/.opencode/command/spec_kit/assets/spec_kit_research_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_research_auto.yaml
@@ -104,20 +104,38 @@ documentation_levels:
     default: "Research workflow typically supports Level 2+ or Level 3 features"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Research workflow primary outputs
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 1+ (Baseline)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -596,7 +614,7 @@ workflow:
     - Include documentation quality checks
     outputs:
     - quality_checklist: generated
-    template: .opencode/skill/system-spec-kit/templates/checklist.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/checklist.md  # Use level from available_templates based on complexity
     validation: checklist_generated
     
     # CONFIDENCE CHECKPOINT
@@ -638,7 +656,7 @@ workflow:
     - decision_rationale
     level_3_documents:
     - decision-record-[name].md: "For significant architecture decisions (Level 3 requirement)"
-    template: .opencode/skill/system-spec-kit/templates/decision-record.md
+    template: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md  # Level 3+ only
     validation: solution_designed
 
   step_8_research_compilation:

--- a/.opencode/command/spec_kit/assets/spec_kit_research_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_research_confirm.yaml
@@ -104,20 +104,38 @@ documentation_levels:
     default: "Research workflow typically supports Level 2+ or Level 3 features"
 
 # ─────────────────────────────────────────────────────────────────
-# AVAILABLE TEMPLATES
+# AVAILABLE TEMPLATES (Level-Specific)
 # ─────────────────────────────────────────────────────────────────
 available_templates:
-  # Research workflow primary outputs
-  research: .opencode/skill/system-spec-kit/templates/research.md
-  # Level 3 (Full)
-  decision_record: .opencode/skill/system-spec-kit/templates/decision-record.md
-  # Level 2+ (Verification)
-  checklist: .opencode/skill/system-spec-kit/templates/checklist.md
-  # Level 1+ (Baseline)
-  spec: .opencode/skill/system-spec-kit/templates/spec.md
-  # Utility (any level)
-  handover: .opencode/skill/system-spec-kit/templates/handover.md
-  debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
+  # Default level when not explicitly specified
+  default_level: level_2
+
+  # Level 1 - Baseline (<100 LOC)
+  level_1:
+    spec: .opencode/skill/system-spec-kit/templates/level_1/spec.md
+
+  # Level 2 - Verification (100-499 LOC)
+  level_2:
+    spec: .opencode/skill/system-spec-kit/templates/level_2/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_2/checklist.md
+
+  # Level 3 - Full (>=500 LOC)
+  level_3:
+    spec: .opencode/skill/system-spec-kit/templates/level_3/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md
+
+  # Level 3+ - Extended (Complex/Enterprise)
+  level_3_plus:
+    spec: .opencode/skill/system-spec-kit/templates/level_3+/spec.md
+    checklist: .opencode/skill/system-spec-kit/templates/level_3+/checklist.md
+    decision_record: .opencode/skill/system-spec-kit/templates/level_3+/decision-record.md
+
+  # Shared templates (available at any level)
+  shared:
+    research: .opencode/skill/system-spec-kit/templates/research.md
+    handover: .opencode/skill/system-spec-kit/templates/handover.md
+    debug_delegation: .opencode/skill/system-spec-kit/templates/debug-delegation.md
 
 # ─────────────────────────────────────────────────────────────────
 # PARALLEL DISPATCH CONFIGURATION
@@ -657,7 +675,7 @@ workflow:
     - Include documentation quality checks
     outputs:
     - quality_checklist: generated
-    template: .opencode/skill/system-spec-kit/templates/checklist.md
+    template: .opencode/skill/system-spec-kit/templates/level_2/checklist.md  # Use level from available_templates based on complexity
     validation: checklist_generated
     
     # CONFIDENCE CHECKPOINT
@@ -704,7 +722,7 @@ workflow:
     - decision_rationale
     level_3_documents:
     - decision-record-[name].md: "For significant architecture decisions (Level 3 requirement)"
-    template: .opencode/skill/system-spec-kit/templates/decision-record.md
+    template: .opencode/skill/system-spec-kit/templates/level_3/decision-record.md  # Level 3+ only
     validation: solution_designed
     checkpoint:
       question: "Step 7 Complete: Solution designed. Review architecture?"


### PR DESCRIPTION
## Summary
- Updates `available_templates:` section in 9 YAML config files to use level-specific template paths
- Fixes "File not found" errors when workflows tried to read non-existent root-level templates
- Inline template references updated from root paths (e.g., `templates/spec.md`) to level-specific paths (e.g., `templates/level_2/spec.md`)

## Files Changed
**spec_kit/assets/ (8 files):**
- `spec_kit_plan_auto.yaml` / `spec_kit_plan_confirm.yaml`
- `spec_kit_complete_auto.yaml` / `spec_kit_complete_confirm.yaml`
- `spec_kit_research_auto.yaml` / `spec_kit_research_confirm.yaml`
- `spec_kit_implement_auto.yaml` / `spec_kit_implement_confirm.yaml`

**create/assets/ (1 file):**
- `create_skill.yaml`

## Test plan
- [ ] Verify spec_kit workflows can read templates without "file not found" errors
- [ ] Test `/spec_kit:plan`, `/spec_kit:complete`, `/spec_kit:research`, `/spec_kit:implement` commands
- [ ] Verify `/create:skill` command works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)