### PR TITLE
v1.0.7.2: Remove outdated model version references

### DIFF
--- a/.opencode/command/spec_kit/assets/spec_kit_complete_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_complete_auto.yaml
@@ -337,7 +337,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -369,7 +369,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -1236,7 +1236,7 @@ workflow:
     # INLINE 4-AGENT PARALLEL EXPLORATION
     # Self-contained exploration - no external skill dependency
     parallel_dispatch_note: |
-      This phase dispatches 4 parallel Sonnet agents directly via Task tool.
+      This phase dispatches 4 parallel agents directly via Task tool.
       Agents: Architecture Explorer, Feature Explorer, Dependency Explorer, Test Explorer.
       No additional question is asked because parallel dispatch is integral to this phase.
 

--- a/.opencode/command/spec_kit/assets/spec_kit_complete_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_complete_confirm.yaml
@@ -346,7 +346,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -378,7 +378,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -1207,7 +1207,7 @@ workflow:
     # INLINE 4-AGENT PARALLEL EXPLORATION
     # Self-contained exploration - no external skill dependency
     parallel_dispatch_note: |
-      This phase dispatches 4 parallel Sonnet agents directly via Task tool.
+      This phase dispatches 4 parallel agents directly via Task tool.
       Agents: Architecture Explorer, Feature Explorer, Dependency Explorer, Test Explorer.
       No additional question is asked because parallel dispatch is integral to this phase.
 

--- a/.opencode/command/spec_kit/assets/spec_kit_debug_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_debug_auto.yaml
@@ -106,7 +106,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -138,7 +138,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -185,10 +185,10 @@ multi_agent_config:
         description: "One agent handles all phases (default)"
       - id: B
         label: "Multi-Agent (1+2)"
-        description: "1 Opus + 2 Sonnet for parallel hypothesis generation"
+        description: "1 orchestrator + 2 workers for parallel hypothesis generation"
       - id: C
         label: "Multi-Agent (1+3)"
-        description: "1 Opus + 3 Sonnet for comprehensive analysis"
+        description: "1 orchestrator + 3 workers for comprehensive analysis"
 
   worker_output_format:
     structure: json

--- a/.opencode/command/spec_kit/assets/spec_kit_debug_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_debug_confirm.yaml
@@ -106,7 +106,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -138,7 +138,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -185,10 +185,10 @@ multi_agent_config:
         description: "One agent handles all phases (default)"
       - id: B
         label: "Multi-Agent (1+2)"
-        description: "1 Opus + 2 Sonnet for parallel hypothesis generation"
+        description: "1 orchestrator + 2 workers for parallel hypothesis generation"
       - id: C
         label: "Multi-Agent (1+3)"
-        description: "1 Opus + 3 Sonnet for comprehensive analysis"
+        description: "1 orchestrator + 3 workers for comprehensive analysis"
 
   worker_output_format:
     structure: json

--- a/.opencode/command/spec_kit/assets/spec_kit_implement_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_implement_auto.yaml
@@ -256,7 +256,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -288,7 +288,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"

--- a/.opencode/command/spec_kit/assets/spec_kit_implement_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_implement_confirm.yaml
@@ -255,7 +255,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -287,7 +287,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"

--- a/.opencode/command/spec_kit/assets/spec_kit_plan_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_plan_auto.yaml
@@ -234,7 +234,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -266,7 +266,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -727,7 +727,7 @@ workflow:
     # INLINE 4-AGENT PARALLEL EXPLORATION
     # Self-contained exploration - no external skill dependency
     parallel_dispatch_note: |
-      This phase dispatches 4 parallel Sonnet agents directly via Task tool.
+      This phase dispatches 4 parallel agents directly via Task tool.
       Agents: Architecture Explorer, Feature Explorer, Dependency Explorer, Test Explorer.
       No additional question is asked because parallel dispatch is integral to this phase.
 

--- a/.opencode/command/spec_kit/assets/spec_kit_plan_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_plan_confirm.yaml
@@ -230,7 +230,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -262,7 +262,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -768,7 +768,7 @@ workflow:
     # INLINE 4-AGENT PARALLEL EXPLORATION
     # Self-contained exploration - no external skill dependency
     parallel_dispatch_note: |
-      This phase dispatches 4 parallel Sonnet agents directly via Task tool.
+      This phase dispatches 4 parallel agents directly via Task tool.
       Agents: Architecture Explorer, Feature Explorer, Dependency Explorer, Test Explorer.
       No additional question is asked because parallel dispatch is integral to this phase.
 

--- a/.opencode/command/spec_kit/assets/spec_kit_research_auto.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_research_auto.yaml
@@ -219,7 +219,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -251,7 +251,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -295,13 +295,13 @@ multi_agent_config:
     options:
       - id: A
         label: "Single Agent"
-        description: "Execute with one Opus agent (default)"
+        description: "Execute with one agent (default)"
       - id: B
         label: "Multi-Agent (1+2)"
-        description: "1 Opus orchestrator + 2 Sonnet workers"
+        description: "1 orchestrator + 2 workers"
       - id: C
         label: "Multi-Agent (1+3)"
-        description: "1 Opus orchestrator + 3 Sonnet workers"
+        description: "1 orchestrator + 3 workers"
 
   worker_output_format:
     structure: json

--- a/.opencode/command/spec_kit/assets/spec_kit_research_confirm.yaml
+++ b/.opencode/command/spec_kit/assets/spec_kit_research_confirm.yaml
@@ -218,7 +218,7 @@ multi_agent_config:
     multi_small:
       id: B
       label: "Multi-Agent (1+2)"
-      description: "1 Opus orchestrator + 2 Sonnet parallel workers"
+      description: "1 orchestrator + 2 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -250,7 +250,7 @@ multi_agent_config:
     multi_large:
       id: C
       label: "Multi-Agent (1+3)"
-      description: "1 Opus orchestrator + 3 Sonnet parallel workers"
+      description: "1 orchestrator + 3 parallel workers"
       orchestrator:
         model: "opus"
         role: "coordinator"
@@ -294,13 +294,13 @@ multi_agent_config:
     options:
       - id: A
         label: "Single Agent"
-        description: "Execute with one Opus agent (default)"
+        description: "Execute with one agent (default)"
       - id: B
         label: "Multi-Agent (1+2)"
-        description: "1 Opus orchestrator + 2 Sonnet workers"
+        description: "1 orchestrator + 2 workers"
       - id: C
         label: "Multi-Agent (1+3)"
-        description: "1 Opus orchestrator + 3 Sonnet workers"
+        description: "1 orchestrator + 3 workers"
 
   worker_output_format:
     structure: json

--- a/.opencode/command/spec_kit/complete.md
+++ b/.opencode/command/spec_kit/complete.md
@@ -4,137 +4,125 @@ argument-hint: "<feature-description> [:auto|:confirm] [:with-research] [:auto-d
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** This workflow requires 2-3 user interactions (down from 4).
+**Round-trip optimization:** This workflow requires only 1 user interaction (all questions asked together), with an optional follow-up only if research phase triggers.
 
 ---
 
-## 🔒 PHASE 1: INPUT COLLECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
-
-├─ IF $ARGUMENTS is empty, undefined, or whitespace-only (ignoring :auto/:confirm flags):
-│   │
-│   ├─ ASK user: "What feature would you like to build?"
-│   ├─ WAIT for user response (DO NOT PROCEED)
-│   ├─ Store response as: feature_description
-│   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-│
-└─ IF $ARGUMENTS contains content:
-    ├─ Store as: feature_description
-    └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-
-**STOP HERE** - Wait for user to provide the feature description before continuing.
-
-⛔ HARD STOP: DO NOT read past this phase until STATUS = ✅ PASSED
-⛔ NEVER infer features from context, screenshots, or conversation history
-```
-
-**Phase 1 Output:** `feature_description = ________________`
-
----
-
-## 🔒 PHASE 2: CONSOLIDATED SETUP (Spec Folder + Execution Mode)
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 1 PASSES:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
 1. CHECK for mode suffix in command invocation:
-   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, still ask Q1)
-   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, still ask Q1)
-   └─ No suffix → execution_mode = "ASK" (include Q2 in consolidated prompt)
+   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, omit Q2)
+   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, omit Q2)
+   └─ No suffix → execution_mode = "ASK" (include Q2 in prompt)
 
-2. Search for related spec folders:
+2. CHECK for special flags:
+   ├─ ":with-research" flag → research_requested = TRUE (pre-set, omit Q3)
+   ├─ ":auto-debug" flag → auto_debug = TRUE
+   └─ No flags → include Q3 in prompt
+
+3. CHECK if $ARGUMENTS contains a feature description:
+   ├─ IF $ARGUMENTS has content (ignoring flags) → feature_description = $ARGUMENTS, omit Q0
+   └─ IF $ARGUMENTS is empty → include Q0 in prompt
+
+4. Search for related spec folders:
    $ ls -d specs/*/ 2>/dev/null | tail -10
 
-3. ASK user with CONSOLIDATED prompt (bundle applicable questions):
+5. Determine if memory loading question is needed:
+   - Will be asked ONLY if user selects A or C for spec folder AND memory/ has files
+   - Include Q5 placeholder with note "(if using existing spec with memory files)"
+
+6. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
 
    ┌────────────────────────────────────────────────────────────────┐
    │ **Before proceeding, please answer:**                          │
    │                                                                │
-   │ **1. Spec Folder** (required):                                 │
+   │ **Q0. Feature Description** (if not provided in command):      │
+   │    What feature would you like to build?                       │
+   │                                                                │
+   │ **Q1. Spec Folder** (required):                                │
    │    A) Use existing: [suggest if related found]                 │
-   │    B) Create new spec folder                                   │
+   │    B) Create new spec folder: specs/[###]-[feature-slug]/      │
    │    C) Update related spec: [if partial match found]            │
    │    D) Skip documentation                                       │
    │                                                                │
-   │ **2. Execution Mode** (if no :auto/:confirm suffix):             │
+   │ **Q2. Execution Mode** (if no :auto/:confirm suffix):            │
    │    A) Autonomous - Execute all 14 steps without approval       │
    │    B) Interactive - Pause at each step for approval            │
    │                                                                │
-   │ Reply with choices, e.g.: "B, A" or "A" (if mode pre-set)      │
+   │ **Q3. Research Phase** (if no :with-research flag):             │
+   │    A) Skip research - Proceed directly to specification         │
+   │    B) Include research - Run 9-step research first              │
+   │                                                                │
+   │ **Q4. Dispatch Mode** (required):                              │
+   │    A) Single Agent - Execute with one agent (Recommended)      │
+   │    B) Multi-Agent (1+2) - 1 orchestrator + 2 workers           │
+   │    C) Multi-Agent (1+3) - 1 orchestrator + 3 workers           │
+   │                                                                │
+   │ **Q5. Memory Context** (if using existing spec with memory/):  │
+   │    A) Load most recent memory file                              │
+   │    B) Load all recent files, up to 3                            │
+   │    C) Skip (start fresh)                                       │
+   │                                                                │
+   │ Reply with answers, e.g.: "B, A, A, A" or "Add auth, B, A, A, A, C" │
    └────────────────────────────────────────────────────────────────┘
 
-4. WAIT for user response (DO NOT PROCEED)
+7. WAIT for user response (DO NOT PROCEED)
 
-5. Parse response and store results:
-   - spec_choice = [A/B/C/D] (first answer)
-   - spec_path = [path or null if D]
-   - execution_mode = [AUTONOMOUS/INTERACTIVE] (from suffix or second answer)
+8. Parse response and store ALL results:
+   - feature_description = [from Q0 or $ARGUMENTS]
+   - spec_choice = [A/B/C/D from Q1]
+   - spec_path = [derived path or null if D]
+   - execution_mode = [AUTONOMOUS/INTERACTIVE from suffix or Q2]
+   - research_triggered = [yes/no from :with-research flag or Q3]
+   - dispatch_mode = [single/multi_small/multi_large from Q4]
+   - memory_choice = [A/B/C from Q5, or N/A if not applicable]
 
-6. SET STATUS: ✅ PASSED (Stateless - no .spec-active file created)
+9. Execute background operations based on choices:
+   - IF memory_choice == A: Load most recent memory file
+   - IF memory_choice == B: Load up to 3 recent memory files
+   - IF dispatch_mode is multi_*: Note parallel dispatch will be used
 
-**STOP HERE** - Wait for user to select A/B/C/D and execution mode before continuing.
+10. SET STATUS: ✅ PASSED
+
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
 
 ⛔ HARD STOP: DO NOT proceed until user explicitly answers
 ⛔ NEVER auto-create spec folders without user confirmation
 ⛔ NEVER auto-select execution mode without suffix or explicit choice
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 2 Output:** `spec_choice = ___` | `spec_path = ________________` | `execution_mode = ________________`
+**Phase Output:**
+- `feature_description = ________________`
+- `spec_choice = ___` | `spec_path = ________________`
+- `execution_mode = ________________`
+- `research_triggered = ________________`
+- `dispatch_mode = ________________`
+- `memory_loaded = ________________`
 
 ---
 
-## 🔀 PHASE 3: OPTIONAL RESEARCH PHASE (Conditional)
+## 🔀 OPTIONAL: RESEARCH PHASE CHECKPOINT (If Triggered)
 
 **STATUS: ☐ SKIP / ☐ TRIGGERED**
 
-> **Optional Chained Workflow:** This phase integrates `/spec_kit:research` into the complete workflow when triggered.
+> **This is the ONLY additional user interaction** - occurs only if research_triggered == TRUE from unified setup.
 
 ```
-EXECUTE AFTER PHASE 2 PASSES:
-
-1. CHECK for research trigger:
-
-├─ IF `:with-research` flag present in command:
-│   ├─ research_triggered = TRUE
-│   └─ trigger_reason = "explicit_flag"
-│
-├─ ELSE evaluate confidence from Step 1-2 analysis:
-│   ├─ IF confidence_score < 60%:
-│   │   ├─ SUGGEST research:
-│   │   │   ┌────────────────────────────────────────────────────────┐
-│   │   │   │ ⚠️ Technical uncertainty detected (confidence: [NN%])   │
-│   │   │   │                                                        │
-│   │   │   │ Would you like to run a research phase first?           │
-│   │   │   │                                                        │
-│   │   │   │ A) Yes - Run 9-step research workflow before planning   │
-│   │   │   │ B) No - Proceed directly to specification               │
-│   │   │   │ C) Review - Show me what's uncertain first              │
-│   │   │   └────────────────────────────────────────────────────────┘
-│   │   ├─ WAIT for user response
-│   │   ├─ IF A selected:
-│   │   │   ├─ research_triggered = TRUE
-│   │   │   └─ trigger_reason = "uncertainty_detected"
-│   │   └─ IF B or C selected:
-│   │       └─ research_triggered = FALSE
-│   │
-│   └─ ELSE (confidence >= 60%):
-│       └─ research_triggered = FALSE
-
-2. IF research_triggered == TRUE:
+IF research_triggered == TRUE:
 
 ├─ Display: "📚 Initiating research phase..."
 ├─ Execute research workflow (9 steps):
-│   ├─ Use same spec_path from Phase 2
+│   ├─ Use same spec_path from unified setup
 │   ├─ Use same execution_mode (auto/confirm)
 │   ├─ Steps 1-9 of research workflow
 │   └─ Creates: research.md in spec folder
@@ -148,145 +136,39 @@ EXECUTE AFTER PHASE 2 PASSES:
 │   │ Created: research.md (17 sections)                             │
 │   │ Key Findings: [brief 2-3 bullet summary]                       │
 │   │                                                                │
-│   │ Current workflow progress:                                      │
-│   │ ✅ Phase 1-2: Input + Setup complete                           │
-│   │ ✅ Phase 3: Research complete                                  │
-│   │ ☐ Steps 1-14: Main workflow pending                             │
-│   │                                                                │
-│   │ Continue to Step 1 (Request Analysis)? [Y/n/review]            │
-│   │                                                                │
-│   │ Options:                                                       │
-│   │   Y - Continue to main workflow                                 │
-│   │   n - Pause workflow here                                       │
-│   │   review - Review research.md before continuing                │
+│   │ Continue to main workflow? [Y/n/review]                         │
 │   └────────────────────────────────────────────────────────────────┘
 │
 ├─ WAIT for user response
 ├─ IF 'review' → Read and display research.md, re-prompt
-├─ IF 'n' → Pause workflow, SET STATUS: ⏸️ PAUSED
-└─ IF 'Y' → SET STATUS: ✅ PASSED, proceed with research context loaded
+├─ IF 'n' → Pause workflow
+└─ IF 'Y' → Continue with research context loaded
 
-3. IF research_triggered == FALSE:
-└─ SET STATUS: ⏭️ SKIP (no research needed)
-
-**STOP HERE** - If research triggered, wait for checkpoint confirmation before continuing.
-
-⛔ DO NOT skip checkpoint prompt after research completes
+IF research_triggered == FALSE:
+└─ Skip directly to workflow execution
 ```
-
-**Phase 3 Output:** `research_triggered = [yes/no]` | `research_findings = ________________`
-
----
-
-## 🔒 PHASE 4: DISPATCH MODE SELECTION
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 3 PASSES OR SKIPS:
-
-1. DISPLAY dispatch mode options:
-
-   ┌────────────────────────────────────────────────────────────────┐
-   │ **Dispatch Mode** (required):                                  │
-   │                                                                │
-   │ A) Single Agent - Execute with one Opus agent (default)        │
-   │ B) Multi-Agent (1+2) - 1 Opus orchestrator + 2 Sonnet workers  │
-   │ C) Multi-Agent (1+3) - 1 Opus orchestrator + 3 Sonnet workers  │
-   │                                                                │
-   │ Reply with A, B, or C                                          │
-   └────────────────────────────────────────────────────────────────┘
-
-2. WAIT for user response (DO NOT PROCEED)
-
-3. Parse response and store:
-   ├─ "A" or "single" → dispatch_mode = "single"
-   ├─ "B" or "1+2" → dispatch_mode = "multi_small"
-   ├─ "C" or "1+3" → dispatch_mode = "multi_large"
-   └─ Invalid → Re-prompt with options
-
-4. IF dispatch_mode == "multi_small" or "multi_large":
-   ├─ Acknowledge: "Multi-agent mode selected. Workers will be dispatched for parallel exploration."
-   └─ Note: Orchestrator (Opus) coordinates, Workers (Sonnet) execute focused domains
-
-5. SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select dispatch mode before continuing.
-
-⛔ HARD STOP: DO NOT proceed until dispatch mode is selected
-```
-
-**Phase 4 Output:** `dispatch_mode = [single/multi_small/multi_large]`
-
----
-
-## 🔒 PHASE 5: MEMORY CONTEXT LOADING (Conditional)
-
-**STATUS: ☐ BLOCKED / ☐ N/A**
-
-> **Memory Context Loading:** This phase implements AGENTS.md Section 2 "Memory Context Loading". Uses A/B/C/D selection format as shown below.
-
-```
-EXECUTE AFTER PHASE 4 PASSES:
-
-CHECK spec_choice value from Phase 2:
-
-├─ IF spec_choice == D (Skip):
-│   └─ SET STATUS: ⏭️ N/A (no spec folder, no memory)
-│
-├─ IF spec_choice == B (Create new):
-│   └─ SET STATUS: ⏭️ N/A (new folder has no memory)
-│
-└─ IF spec_choice == A or C (Use existing):
-    │
-    ├─ Check: Does spec_path/memory/ exist AND contain files?
-    │
-    ├─ IF memory/ is empty or missing:
-    │   └─ SET STATUS: ⏭️ N/A (no memory to load)
-    │
-    └─ IF memory/ has files:
-        │
-        ├─ ASK user:
-        │   ┌────────────────────────────────────────────────────┐
-        │   │ "Load previous context from this spec folder?"     │
-        │   │                                                    │
-        │   │ A) Load most recent memory file (quick refresh)     │
-        │   │ B) Load all recent files, up to 3 (comprehensive).  │
-        │   │ C) List all files and select specific                │
-        │   │ D) Skip (start fresh, no context)                  │
-        │   └────────────────────────────────────────────────────┘
-        │
-        ├─ WAIT for user response
-        ├─ Execute loading based on choice (use Read tool)
-        ├─ Acknowledge loaded context briefly
-        └─ SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select memory loading option before continuing.
-
-⛔ HARD STOP: DO NOT proceed until STATUS = ✅ PASSED or ⏭️ N/A
-```
-
-**Phase 5 Output:** `memory_loaded = [yes/no]` | `context_summary = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                      | REQUIRED STATUS    | YOUR STATUS | OUTPUT VALUE                                  |
-| -------------------------- | ------------------ | ----------- | --------------------------------------------- |
-| PHASE 1: INPUT             | ✅ PASSED           | ______      | feature_description: ______                   |
-| PHASE 2: SETUP (Spec+Mode) | ✅ PASSED           | ______      | spec_choice: ___ / spec_path: ___ / mode: ___ |
-| PHASE 3: RESEARCH          | ✅ PASSED or ⏭️ SKIP | ______      | research_triggered: ______                    |
-| PHASE 4: DISPATCH MODE     | ✅ PASSED           | ______      | dispatch_mode: ______                         |
-| PHASE 5: MEMORY            | ✅ PASSED or ⏭️ N/A  | ______      | memory_loaded: ______                         |
+| FIELD               | REQUIRED      | YOUR VALUE | SOURCE                    |
+| ------------------- | ------------- | ---------- | ------------------------- |
+| feature_description | ✅ Yes         | ______     | Q0 or $ARGUMENTS          |
+| spec_choice         | ✅ Yes         | ______     | Q1                        |
+| spec_path           | ○ Conditional | ______     | Derived from Q1           |
+| execution_mode      | ✅ Yes         | ______     | Suffix or Q2              |
+| research_triggered  | ✅ Yes         | ______     | :with-research flag or Q3 |
+| dispatch_mode       | ✅ Yes         | ______     | Q4                        |
+| memory_loaded       | ○ Conditional | ______     | Q5 (if existing spec)     |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED or ⏭️ N/A?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Complete" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -296,17 +178,15 @@ VERIFICATION CHECK:
 **YOU ARE IN VIOLATION IF YOU:**
 
 **Phase Violations:**
-- Started reading the workflow section before all phases passed
-- Proceeded without asking user for feature description (Phase 1)
-- Asked spec folder and execution mode as SEPARATE questions instead of consolidated (Phase 2)
-- Auto-created or assumed a spec folder without A/B/C/D choice (Phase 2)
-- Skipped dispatch mode selection (Phase 4)
-- Assumed single-agent mode without explicit user choice (Phase 4)
-- Skipped memory prompt when using existing folder with memory files (Phase 5)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Proceeded without asking user for feature description when not in $ARGUMENTS
+- Auto-created or assumed a spec folder without user confirmation
+- Auto-selected dispatch mode without explicit user choice
 - Inferred feature from context instead of explicit user input
 - Auto-selected execution mode without suffix or explicit user choice
 
-**Workflow Violations (Steps 1-12):**
+**Workflow Violations (Steps 1-14):**
 - **Skipped Phase Gate and jumped directly to implementation code**
 - **Started writing code before completing Steps 1-7 (Planning Phase)**
 - **Did not mark tasks [x] in tasks.md during Step 10**
@@ -329,10 +209,10 @@ VERIFICATION CHECK:
 ```
 FOR PHASE VIOLATIONS:
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 
 FOR WORKFLOW VIOLATIONS:
 1. STOP immediately
@@ -764,7 +644,7 @@ This workflow supports smart parallel sub-agent dispatch for eligible phases usi
 
 ### Step 6: 4-Agent Parallel Exploration (Automatic)
 
-Step 6 (Planning) automatically dispatches 4 Sonnet agents in parallel via the Task tool:
+Step 6 (Planning) automatically dispatches 4 agents in parallel via the Task tool:
 
 1. **Architecture Explorer** - Project structure, entry points, component connections
 2. **Feature Explorer** - Similar features, related patterns
@@ -792,24 +672,20 @@ After agents return, hypotheses are verified by reading identified files and bui
 
 This command routes to multiple specialized agents at different steps:
 
-| Step/Phase             | Agent       | Model      | Fallback  | Purpose                                 |
-| ---------------------- | ----------- | ---------- | --------- | --------------------------------------- |
-| Phase 3 (Research)     | `@research` | sonnet     | `general` | 9-step research workflow (if triggered) |
-| Step 3 (Specification) | `@speckit`  | **sonnet** | `general` | Template-first spec folder creation     |
-| Step 11 (Verification) | `@review`   | sonnet     | `general` | P0/P1 checklist verification (blocking) |
+| Step/Phase             | Agent       | Fallback  | Purpose                                 |
+| ---------------------- | ----------- | --------- | --------------------------------------- |
+| Phase 3 (Research)     | `@research` | `general` | 9-step research workflow (if triggered) |
+| Step 3 (Specification) | `@speckit`  | `general` | Template-first spec folder creation     |
+| Step 11 (Verification) | `@review`   | `general` | P0/P1 checklist verification (blocking) |
 
 ### Model Preferences
 
-| Agent       | Default Model | Use Opus When                         |
-| ----------- | ------------- | ------------------------------------- |
-| `@speckit`  | **Sonnet**    | User explicitly requests ("use opus") |
-| `@research` | Sonnet        | Complex multi-system architecture     |
-| `@review`   | Sonnet        | Level 3+ governance review            |
+Model selection is handled automatically by the system based on task complexity.
 
 ### How Multi-Agent Routing Works
 
 1. **Phase 3 (Optional Research)**: When `:with-research` flag is present OR confidence < 60%, dispatches to `@research` agent for comprehensive technical investigation
-2. **Step 3 (Specification)**: Dispatches to `@speckit` agent with `model: sonnet` for template-first spec creation
+2. **Step 3 (Specification)**: Dispatches to `@speckit` agent for template-first spec creation
 3. **Step 11 (Checklist Verification)**: Dispatches to `@review` agent with `blocking: true` - P0 failures halt workflow
 
 ### Agent Dispatch Templates

--- a/.opencode/command/spec_kit/debug.md
+++ b/.opencode/command/spec_kit/debug.md
@@ -4,148 +4,100 @@ argument-hint: "[spec-folder-path]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Key Rule:** Model selection is MANDATORY. You MUST ask the user which model to use before dispatching the sub-agent.
+**Round-trip optimization:** This workflow requires only 1 user interaction (all questions asked together).
+
+**Key Rule:** Model selection is MANDATORY and included in the consolidated prompt.
 
 ---
 
-## 🔒 PHASE 1: CONTEXT DETECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
 1. CHECK for spec folder in $ARGUMENTS:
+   ├─ IF $ARGUMENTS contains a spec folder path → validate and store
+   └─ IF $ARGUMENTS is empty → auto-detect from recent memory files
 
-├─ IF $ARGUMENTS contains a spec folder path:
-│   │
-│   ├─ Validate path exists: ls -d [spec_folder_input] 2>/dev/null
-│   │
-│   ├─ IF path exists:
-│   │   ├─ Store as: spec_path
-│   │   ├─ detection_method = "provided"
-│   │   └─ Continue to error context gathering
-│   │
-│   └─ IF path NOT found:
-│       ├─ SHOW: "Spec folder not found: [path]"
-│       ├─ ASK: "Would you like to:"
-│       │   ┌────────────────────────────────────────────────────────────┐
-│       │   │ A) Try auto-detection (search for recent sessions)         │
-│       │   │ B) Provide a different path                                │
-│       │   │ C) Cancel                                                  │
-│       │   └────────────────────────────────────────────────────────────┘
-│       └─ WAIT for user response
-│
-└─ IF $ARGUMENTS is empty (auto-detect mode):
-    │
-    ├─ Find most recent memory file:
-    │   Glob("specs/**/memory/*.md") → Results sorted by modification time, take first
-    │
-    ├─ IF session found:
-    │   ├─ Store as: spec_path (extract from memory file path)
-    │   ├─ detection_method = "recent"
-    │   └─ Continue to error context gathering
-    │
-    └─ IF NO session found:
-        ├─ SHOW: "No active session detected"
-        ├─ ASK: "Would you like to:"
-        │   ┌────────────────────────────────────────────────────────────┐
-        │   │ A) List available spec folders and select one              │
-        │   │ B) Debug without a spec folder (ad-hoc mode)               │
-        │   │ C) Cancel                                                  │
-        │   └────────────────────────────────────────────────────────────┘
-        └─ WAIT for user response
+2. Auto-detect spec folder if needed:
+   - Glob("specs/**/memory/*.md") → Sort by modification time, take first
+   - IF found: spec_path = extracted path, detection_method = "recent"
+   - IF not found: detection_method = "none" (include Q0 in prompt)
 
-2. GATHER ERROR CONTEXT from conversation:
+3. GATHER ERROR CONTEXT from conversation (background scan):
+   - Scan for: error messages, stack traces, affected files, previous attempts
+   - IF found: Store as error_message, affected_files, previous_attempts
+   - IF not found: Include Q1 in prompt
 
-├─ Scan recent conversation for:
-│   ├─ Error messages (look for stack traces, error codes, exceptions)
-│   ├─ Affected file paths (files mentioned in errors or recent edits)
-│   ├─ Previous fix attempts (code changes, commands run)
-│   └─ Reproduction steps (how the error was triggered)
-│
-├─ Store extracted context:
-│   ├─ error_message = [extracted error text]
-│   ├─ affected_files = [list of file paths]
-│   ├─ previous_attempts = [list of attempted fixes]
-│   └─ reproduction_steps = [how to reproduce]
-│
-└─ IF no error context found in conversation:
-    ├─ ASK: "What error are you debugging? Please provide:"
-    │   ┌────────────────────────────────────────────────────────────┐
-    │   │ • The error message or unexpected behavior                 │
-    │   │ • Which file(s) are affected                                │
-    │   │ • What you've already tried (if anything)                  │
-    │   └────────────────────────────────────────────────────────────┘
-    └─ WAIT for user response
+4. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
 
-**STOP HERE** - Wait for user to confirm spec folder and provide error context before continuing.
+   ┌────────────────────────────────────────────────────────────────┐
+   │ **Before proceeding, please answer:**                          │
+   │                                                                │
+   │ **Q0. Spec Folder** (if not detected/provided):                │
+   │    Available spec folders: [list if found]                     │
+   │    A) Use: [most recent if detected]                           │
+   │    B) Select different folder (specify path)                   │
+   │    C) Debug without spec folder (ad-hoc mode)                  │
+   │    D) Cancel                                                   │
+   │                                                                │
+   │ **Q1. Error Context** (if not found in conversation):          │
+   │    What error are you debugging? Please provide:               │
+   │    • The error message or unexpected behavior                  │
+   │    • Which file(s) are affected                                 │
+   │    • What you've already tried (if anything)                   │
+   │                                                                │
+   │ **Q2. AI Model** (required):                                   │
+   │    A) Claude - Anthropic (Recommended)                         │
+   │    B) Gemini - Google                                          │
+   │    C) Codex - OpenAI                                           │
+   │    D) Other - Specify                                          │
+   │                                                                │
+   │ **Q3. Dispatch Mode** (required):                              │
+   │    A) Single Agent - One agent (Recommended)                   │
+   │    B) Multi-Agent (1+2) - 1 orchestrator + 2 hypothesis gen    │
+   │    C) Multi-Agent (1+3) - 1 orchestrator + 3 hypothesis gen    │
+   │                                                                │
+   │ Reply with answers, e.g.: "A, A, A" or "A, [error desc], A, A" │
+   └────────────────────────────────────────────────────────────────┘
 
-⛔ HARD STOP: DO NOT proceed until spec_path is confirmed AND error context is gathered
+5. WAIT for user response (DO NOT PROCEED)
+
+6. Parse response and store ALL results:
+   - spec_path = [from Q0 or auto-detected or $ARGUMENTS]
+   - detection_method = [provided/recent/ad-hoc]
+   - error_message = [from Q1 or extracted from conversation]
+   - affected_files = [extracted or from Q1]
+   - previous_attempts = [extracted or from Q1]
+   - selected_model = [from Q2]
+   - dispatch_mode = [single/multi_small/multi_large from Q3]
+
+7. IF dispatch_mode is multi_*:
+   - Note: Orchestrator handles OBSERVE + FIX phases
+   - Note: Workers handle parallel hypothesis generation in ANALYZE phase
+
+8. SET STATUS: ✅ PASSED
+
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
+
+⛔ HARD STOP: DO NOT proceed until user explicitly answers
+⛔ NEVER skip model selection - it is MANDATORY
+⛔ NEVER skip dispatch mode selection - it is MANDATORY
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 1 Output:** `spec_path = ___` | `detection_method = [recent/provided/ad-hoc]` | `error_message = ___` | `affected_files = ___`
-
----
-
-## 🔒 PHASE 2: MODEL + DISPATCH SELECTION [MANDATORY - ALWAYS ASK]
-
-**STATUS: ☐ BLOCKED**
-
-⛔ HARD STOP: You MUST ask the user which model AND dispatch mode to use. DO NOT skip this phase.
-
-```
-DISPLAY EXACTLY:
-
-┌────────────────────────────────────────────────────────────────┐
-│ 🤖 Debug Configuration                                          │
-│                                                                │
-│ **1. Which AI model?**                                         │
-│    A) Claude - Anthropic models                                │
-│    B) Gemini - Google models (Pro/Ultra)                       │
-│    C) Codex - OpenAI models (GPT-4/o1)                         │
-│    D) Other - Specify a different model                        │
-│                                                                │
-│ **2. How should agents be dispatched?**                        │
-│    A) Single Agent - One agent (default)                       │
-│    B) Multi-Agent (1+2) - 1 Opus + 2 Sonnet hypothesis gen     │
-│    C) Multi-Agent (1+3) - 1 Opus + 3 Sonnet hypothesis gen     │
-│                                                                │
-│ Reply with two choices, e.g.: "A, A" or "Claude, B"            │
-└────────────────────────────────────────────────────────────────┘
-
-WAIT for user response.
-
-Parse response:
-├─ First choice → selected_model:
-│   ├─ "A" or "claude" → selected_model = "claude"
-│   ├─ "B" or "gemini" → selected_model = "gemini"
-│   ├─ "C" or "codex" or "gpt" or "openai" → selected_model = "codex"
-│   └─ "D [model]" → selected_model = [user-specified model]
-│
-└─ Second choice → dispatch_mode:
-    ├─ "A" or "single" → dispatch_mode = "single"
-    ├─ "B" or "1+2" → dispatch_mode = "multi_small"
-    └─ "C" or "1+3" → dispatch_mode = "multi_large"
-
-Store: selected_model = ________________
-Store: dispatch_mode = ________________
-
-IF dispatch_mode == "multi_small" or "multi_large":
-├─ Acknowledge: "Multi-agent mode selected."
-├─ Note: Orchestrator (Opus) handles OBSERVE + FIX phases
-└─ Note: Workers (Sonnet) handle parallel hypothesis generation in ANALYZE phase
-
-**STOP HERE** - Wait for user to select model AND dispatch mode before continuing.
-
-⛔ HARD STOP: DO NOT proceed until BOTH selections are made
-```
-
-**Phase 2 Output:** `selected_model = ___` | `dispatch_mode = ___`
+**Phase Output:**
+- `spec_path = ________________` | `detection_method = ________________`
+- `error_message = ________________`
+- `affected_files = ________________`
+- `selected_model = ________________`
+- `dispatch_mode = ________________`
 
 ---
 
@@ -153,7 +105,7 @@ IF dispatch_mode == "multi_small" or "multi_large":
 
 **When Gate 3 applies:** When debugging leads to file modifications (Step 5, Option A "Apply the fix").
 
-- If a spec folder was established in Phase 1 → Gate 3 is satisfied
+- If a spec folder was established in unified setup → Gate 3 is satisfied
 - If ad-hoc mode was selected → Gate 3 MUST be asked before applying fixes:
   > **Spec Folder** (required): A) Existing | B) New | C) Update related | D) Skip
 
@@ -164,18 +116,21 @@ IF dispatch_mode == "multi_small" or "multi_large":
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                     | REQUIRED STATUS | YOUR STATUS | OUTPUT VALUE                                  |
-| ------------------------- | --------------- | ----------- | --------------------------------------------- |
-| PHASE 1: CONTEXT          | ✅ PASSED        | ______      | spec_path: ______ / error: ______             |
-| PHASE 2: MODEL + DISPATCH | ✅ PASSED        | ______      | selected_model: ______ / dispatch_mode: _____ |
+| FIELD            | REQUIRED      | YOUR VALUE | SOURCE                     |
+| ---------------- | ------------- | ---------- | -------------------------- |
+| spec_path        | ○ Conditional | ______     | Q0 or auto-detect or $ARGS |
+| detection_method | ✅ Yes         | ______     | Auto-determined            |
+| error_message    | ✅ Yes         | ______     | Q1 or conversation scan    |
+| selected_model   | ✅ Yes         | ______     | Q2                         |
+| dispatch_mode    | ✅ Yes         | ______     | Q3                         |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# /spec_kit:debug" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -183,22 +138,21 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
-- Skipped model selection (Phase 2 is MANDATORY)
-- Skipped dispatch mode selection (Phase 2 is MANDATORY)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Skipped model selection (Q2 is MANDATORY)
+- Skipped dispatch mode selection (Q3 is MANDATORY)
 - Assumed single-agent mode without explicit user choice
-- Assumed error context without extracting from conversation
-- Proceeded without asking user about model AND dispatch mode selection
 - Dispatched sub-agent without creating debug-delegation.md first
 - Did not wait for user response on integration options
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 ---

--- a/.opencode/command/spec_kit/handover.md
+++ b/.opencode/command/spec_kit/handover.md
@@ -4,124 +4,104 @@ argument-hint: "[spec-folder-path]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** Handover uses 1-2 user interactions maximum.
+**Round-trip optimization:** Handover uses only 1 user interaction (all questions asked together).
 
 ---
 
-## 🔒 PHASE 1: INPUT & SPEC DETECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
 1. CHECK for spec folder in $ARGUMENTS:
+   ├─ IF $ARGUMENTS has path → validate path exists
+   └─ IF $ARGUMENTS is empty → auto-detect from recent memory files
 
-├─ IF $ARGUMENTS contains a spec folder path:
-│   │
-│   ├─ Validate path exists: ls -d [spec_folder_input] 2>/dev/null
-│   │
-│   ├─ IF path exists:
-│   │   ├─ Store as: spec_path
-│   │   ├─ detection_method = "provided"
-│   │   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-│   │
-│   └─ IF path NOT found:
-│       ├─ SHOW: "Spec folder not found: [path]"
-│       ├─ ASK: "Would you like to:"
-│       │   ┌────────────────────────────────────────────────────────────┐
-│       │   │ A) Try auto-detection (search for recent sessions)         │
-│       │   │ B) Provide a different path                                │
-│       │   │ C) Cancel                                                  │
-│       │   └────────────────────────────────────────────────────────────┘
-│       └─ WAIT for user response
-│
-└─ IF $ARGUMENTS is empty (auto-detect mode):
-    │
-    ├─ Find most recent memory file (Stateless - no .spec-active marker)
-    │   Glob("specs/**/memory/*.md") → Results sorted by modification time, take first
-    │
-    ├─ IF session found:
-    │   ├─ Store as: spec_path (extract from memory file path)
-    │   ├─ detection_method = "recent"
-    │   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-    │
-    └─ IF NO session found:
-        ├─ SHOW: "No active session detected"
-        ├─ ASK: "Would you like to:"
-        │   ┌────────────────────────────────────────────────────────────┐
-        │   │ A) List available spec folders and select one              │
-        │   │ B) Cancel handover                                         │
-        │   └────────────────────────────────────────────────────────────┘
-        └─ WAIT for user response
+2. Auto-detect spec folder if needed:
+   - Glob("specs/**/memory/*.md") → Sort by modification time, take first
+   - IF found: spec_path = extracted path, detection_method = "recent"
+   - IF not found: detection_method = "none" (include Q0 in prompt)
 
-**STOP HERE** - Wait for user to provide or confirm a valid spec folder path before continuing.
+3. Run pre-handover validation (background, strict mode):
+   - Check: ANCHORS_VALID, PRIORITY_TAGS, PLACEHOLDER_FILLED
+   - Store: validation_status = [passed/warnings/errors]
 
-⛔ HARD STOP: DO NOT proceed until a valid spec_path is confirmed
+4. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
+
+   ┌────────────────────────────────────────────────────────────────┐
+   │ **Before proceeding, please answer:**                          │
+   │                                                                │
+   │ **Q0. Spec Folder** (if not detected/provided):                │
+   │    No active session detected. Available spec folders:         │
+   │    [list folders if found]                                     │
+   │    A) List available spec folders and select one               │
+   │    B) Cancel handover                                          │
+   │                                                                │
+   │ **Q1. Confirm Detected Session** (if auto-detected):            │
+   │    Detected: [spec_path] (last activity: [date])               │
+   │    A) Yes, create handover for this session                    │
+   │    B) No, select a different spec folder                       │
+   │    C) Cancel                                                   │
+   │                                                                │
+   │ **Q2. Validation Issues** (if validation found warnings/errors)│
+   │    Pre-handover validation found issues:                       │
+   │    [list warnings/errors]                                      │
+   │    A) Fix issues before handover                               │
+   │    B) Proceed anyway (warnings transfer to next session)       │
+   │    C) Cancel                                                   │
+   │                                                                │
+   │ Reply with answers, e.g.: "A" or "A, B"                        │
+   └────────────────────────────────────────────────────────────────┘
+
+5. WAIT for user response (DO NOT PROCEED)
+
+6. Parse response and store ALL results:
+   - spec_path = [from Q0/Q1 or auto-detected or $ARGUMENTS]
+   - detection_method = [provided/recent]
+   - validation_choice = [from Q2: FIX/BYPASS, or N/A if passed]
+
+7. Handle redirects if needed:
+   - IF validation_choice == FIX → Fix issues, then re-run validation
+   - IF Q0/Q1 == B → Re-prompt with folder selection only
+   - IF Q0/Q1 == C or Q2 == C → Cancel workflow
+
+8. SET STATUS: ✅ PASSED
+
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
+
+⛔ HARD STOP: DO NOT proceed until user explicitly answers
+⛔ NEVER assume spec folder without user confirmation when path was invalid
+⛔ NEVER skip pre-handover validation
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 1 Output:** `spec_path = ________________` | `detection_method = [recent/provided]`
-
----
-
-## 🔒 PHASE 2: PRE-HANDOVER VALIDATION
-
-**STATUS: ☐ BLOCKED**
-
-Before creating handover, validation runs automatically to ensure clean state.
-
-Strict mode is used to ensure no warnings are passed to the next session.
-
-**Key checks before handover:**
-- **ANCHORS_VALID** - Memory files have balanced anchors
-- **PRIORITY_TAGS** - Remaining tasks are prioritized  
-- **PLACEHOLDER_FILLED** - No incomplete placeholders
-
-```
-EXECUTE AFTER PHASE 1 PASSES:
-
-1. Validation runs automatically (strict mode)
-
-2. IF validation passes:
-   └─ SET STATUS: ✅ PASSED → Proceed to workflow
-
-3. IF validation fails (exit 1 or 2):
-   ├─ SHOW: Validation warnings/errors
-   ├─ ASK: "Would you like to:"
-   │   ┌────────────────────────────────────────────────────────────┐
-   │   │ A) Fix issues before handover                              │
-   │   │ B) Proceed anyway (warnings will transfer to next session) │
-   │   │ C) Cancel                                                  │
-   │   └────────────────────────────────────────────────────────────┘
-   └─ WAIT for user response
-
-**STOP HERE** - Wait for validation to complete or user to confirm bypass before continuing.
-
-⛔ HARD STOP: DO NOT proceed until validation is complete or user confirms bypass
-```
-
-**Phase 2 Output:** `validation = [PASSED/BYPASSED/FIXED]`
+**Phase Output:**
+- `spec_path = ________________` | `detection_method = ________________`
+- `validation_status = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                 | REQUIRED STATUS | YOUR STATUS | OUTPUT VALUE                       |
-| --------------------- | --------------- | ----------- | ---------------------------------- |
-| PHASE 1: INPUT & SPEC | ✅ PASSED        | ______      | spec_path: ______ / method: ______ |
-| PHASE 2: VALIDATION   | ✅ PASSED        | ______      | validation: ______                 |
+| FIELD             | REQUIRED | YOUR VALUE | SOURCE                          |
+| ----------------- | -------- | ---------- | ------------------------------- |
+| spec_path         | ✅ Yes    | ______     | Q0/Q1 or auto-detect or $ARGS   |
+| detection_method  | ✅ Yes    | ______     | Auto-determined                 |
+| validation_status | ✅ Yes    | ______     | Validation check (Q2 if issues) |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Handover" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -129,20 +109,20 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
 - Assumed a spec folder without user confirmation when path was invalid
-- Proceeded without validating spec path exists (Phase 1)
-- Skipped pre-handover validation (Phase 2)
+- Skipped pre-handover validation
 - Created handover without gathering context first
 - Did not display the created file path and continuation instructions
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 ---
@@ -331,7 +311,6 @@ The handover file is created in the spec folder root, NOT in memory/.
 The handover workflow delegates execution work to the dedicated `@handover` agent for token efficiency. The main agent handles validation and user interaction; the sub-agent handles context gathering and file generation.
 
 **Agent File:** `.opencode/agent/handover.md`
-**Model:** Sonnet (cost-efficient for structured handover tasks)
 **Symlink:** `.claude/agents/handover.md`
 
 ### Delegation Architecture
@@ -454,14 +433,14 @@ fallback:
 
 ### Why Dedicated @handover Agent?
 
-| Benefit | Description |
-|---------|-------------|
-| Token efficiency | Heavy context analysis happens in sub-agent context |
-| Cost optimization | Sonnet model for structured tasks (vs Opus for complex) |
+| Benefit               | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| Token efficiency      | Heavy context analysis happens in sub-agent context        |
+| Cost optimization     | Model selected automatically based on task complexity      |
 | Specialized prompting | Agent has handover-specific instructions and anti-patterns |
-| Main agent responsive | User can see progress without waiting |
-| Fallback safety | Commands always work, even without Task tool |
-| Output verification | Agent enforces JSON response format and content validation |
+| Main agent responsive | User can see progress without waiting                      |
+| Fallback safety       | Commands always work, even without Task tool               |
+| Output verification   | Agent enforces JSON response format and content validation |
 
 ---
 
@@ -493,19 +472,19 @@ fallback:
 
 ### Agents
 
-| Agent        | Relationship                                     |
-| ------------ | ------------------------------------------------ |
-| `@handover`  | Dedicated sub-agent for this command             |
+| Agent          | Relationship                                     |
+| -------------- | ------------------------------------------------ |
+| `@handover`    | Dedicated sub-agent for this command             |
 | `@orchestrate` | May coordinate handover in multi-agent workflows |
-| `@speckit`   | Works with spec folders this command reads       |
+| `@speckit`     | Works with spec folders this command reads       |
 
 ### Files
 
-| File | Purpose |
-| ---- | ------- |
-| `.opencode/agent/handover.md` | Agent definition |
+| File                                                            | Purpose            |
+| --------------------------------------------------------------- | ------------------ |
+| `.opencode/agent/handover.md`                                   | Agent definition   |
 | `.opencode/command/spec_kit/assets/spec_kit_handover_full.yaml` | YAML configuration |
-| `.opencode/skill/system-spec-kit/templates/handover.md` | Output template |
+| `.opencode/skill/system-spec-kit/templates/handover.md`         | Output template    |
 
 ---
 
@@ -558,11 +537,11 @@ This command is part of the SpecKit workflow:
 
 After handover is created, provide continuation instructions:
 
-| Condition | Suggested Action | Reason |
-|-----------|------------------|--------|
-| Handover created | Copy continuation prompt | Ready for new session |
-| Ready to continue now | `/spec_kit:resume [spec-folder-path]` | Load context and continue |
-| Want to save more context | `/memory:save [spec-folder-path]` | Preserve additional details |
-| Starting new work | `/spec_kit:complete [feature-description]` | Begin different feature |
+| Condition                 | Suggested Action                           | Reason                      |
+| ------------------------- | ------------------------------------------ | --------------------------- |
+| Handover created          | Copy continuation prompt                   | Ready for new session       |
+| Ready to continue now     | `/spec_kit:resume [spec-folder-path]`      | Load context and continue   |
+| Want to save more context | `/memory:save [spec-folder-path]`          | Preserve additional details |
+| Starting new work         | `/spec_kit:complete [feature-description]` | Begin different feature     |
 
 **ALWAYS** end with: "What would you like to do next?"

--- a/.opencode/command/spec_kit/implement.md
+++ b/.opencode/command/spec_kit/implement.md
@@ -8,230 +8,145 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 
 This command involves FILE MODIFICATIONS. Per AGENTS.md Section 2, Gate 3 MUST be satisfied before implementation.
 
-**Standard Gate 3 Question Format:**
-> **Spec Folder** (required): A) Existing | B) New | C) Update related | D) Skip
-
-**First Message Protocol:** If this command is invoked as the user's FIRST message requesting file modifications, the spec folder question is your FIRST response. No analysis first, no tool calls first.
+**First Message Protocol:** If this command is invoked as the user's FIRST message requesting file modifications, the consolidated setup prompt is your FIRST response. No analysis first, no tool calls first.
 
 **Failure Pattern #5 Warning (Skip Process):**
 > "I already know this" - Triggers: "straightforward", "comprehensive", "fix all", "15 agents"
-> Even exciting implementation requests MUST complete Phase 1-3 blocking gates.
+> Even exciting implementation requests MUST complete the unified setup phase.
 
 **Self-Verification:** Before proceeding to workflow:
-> □ STOP. File modification detected? Did I ask spec folder question? If NO → Ask NOW.
+> □ STOP. File modification detected? Did I ask the consolidated setup prompt? If NO → Ask NOW.
 
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** This workflow requires 2-3 user interactions (down from 4).
+**Round-trip optimization:** This workflow requires only 1 user interaction (all questions asked together).
 
 ---
 
-## 🔒 PHASE 1: INPUT COLLECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
-├─ IF $ARGUMENTS is empty, undefined, or whitespace-only (ignoring :auto/:confirm flags):
-│   │
-│   ├─ Search for available spec folders with plan.md:
-│   │   $ ls -d specs/*/ 2>/dev/null | tail -10
-│   │
-│   ├─ ASK user: "Which spec folder would you like to implement?"
-│   │   Present found folders with plan.md status
-│   ├─ WAIT for user response (DO NOT PROCEED)
-│   ├─ Store response as: spec_folder_input
-│   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-│
-└─ IF $ARGUMENTS contains a spec folder path:
-    ├─ Store as: spec_folder_input
-    └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
+1. CHECK for mode suffix in command invocation:
+   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, omit Q2)
+   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, omit Q2)
+   └─ No suffix → execution_mode = "ASK" (include Q2 in prompt)
 
-**STOP HERE** - Wait for user to specify or select a spec folder before continuing.
+2. CHECK if $ARGUMENTS contains a spec folder path:
+   ├─ IF $ARGUMENTS has a path → spec_folder_input = $ARGUMENTS
+   └─ IF $ARGUMENTS is empty → include Q0 with available folders
 
-⛔ HARD STOP: DO NOT read past this phase until STATUS = ✅ PASSED
-⛔ NEVER infer spec folder from context, .spec-active, or conversation history
-```
+3. Search for available spec folders with plan.md:
+   $ ls -d specs/*/ 2>/dev/null | tail -10
+   Check each for: spec.md, plan.md (required), checklist.md (optional)
 
-**Phase 1 Output:** `spec_folder_input = ________________`
-
----
-
-## 🔒 PHASE 2: CONSOLIDATED SETUP (Validation + Execution Mode)
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 1 PASSES:
-
-1. Validate spec_folder_input exists and has required files:
+4. IF spec_folder_input provided, validate prerequisites:
    $ ls -la [spec_folder_input]/
-
-   Check for:
    - spec.md (REQUIRED)
    - plan.md (REQUIRED)
    - tasks.md (will create if missing)
    - checklist.md (REQUIRED for Level 2+)
 
-2. IF required files missing:
-   ├─ INFORM user: "Missing required files: [list]"
-   ├─ ASK: "Run /spec_kit:plan first, or select different folder?"
-   │   - A) Run /spec_kit:plan to create planning artifacts
-   │   - B) Select a different spec folder
-   └─ WAIT and redirect accordingly
+5. Check if memory/ exists and has files for the spec folder
 
-3. CHECK for mode suffix in command invocation:
-   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, still ask Q1)
-   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, still ask Q1)
-   └─ No suffix → execution_mode = "ASK" (include Q2 in consolidated prompt)
-
-4. IF files exist, ASK user with CONSOLIDATED prompt:
+6. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
 
    ┌────────────────────────────────────────────────────────────────┐
    │ **Before proceeding, please answer:**                          │
    │                                                                │
-   │ **1. Confirm Spec Folder** (required):                          │
+   │ **Q0. Spec Folder** (if not provided in command):              │
+   │    Available folders with plan.md:                             │
+   │    [list folders with status indicators]                       │
+   │    Enter folder path or number:                                │
+   │                                                                │
+   │ **Q1. Confirm Spec Folder** (if path provided):                 │
    │    Folder: [spec_folder_input]                                 │
-   │    ├─ spec.md ✓                                                │
-   │    ├─ plan.md ✓                                                │
-   │    └─ [other files status]                                      │
+   │    ├─ spec.md [✓/✗]                                            │
+   │    ├─ plan.md [✓/✗]                                            │
+   │    └─ checklist.md [✓/✗/optional]                              │
    │                                                                │
    │    A) Yes, implement this spec folder                          │
    │    B) No, select a different spec folder                       │
    │    C) Cancel - I need to plan first                             │
    │                                                                │
-   │ **2. Execution Mode** (if no :auto/:confirm suffix):             │
+   │ **Q2. Execution Mode** (if no :auto/:confirm suffix):            │
    │    A) Autonomous - Execute all 9 steps without approval        │
    │    B) Interactive - Pause at each step for approval            │
    │                                                                │
-   │ Reply with choices, e.g.: "A, A" or "A" (if mode pre-set)      │
+   │ **Q3. Dispatch Mode** (required):                              │
+   │    A) Single Agent - Execute with one agent (Recommended)      │
+   │    B) Multi-Agent (1+2) - 1 orchestrator + 2 workers           │
+   │    C) Multi-Agent (1+3) - 1 orchestrator + 3 workers           │
+   │                                                                │
+   │ **Q4. Memory Context** (if memory/ has files):                  │
+   │    A) Load most recent memory file                              │
+   │    B) Load all recent files, up to 3                            │
+   │    C) Skip (start fresh)                                       │
+   │                                                                │
+   │ Reply with answers, e.g.: "A, A, A" or "specs/007-auth/, A, A, A, B" │
    └────────────────────────────────────────────────────────────────┘
 
-5. WAIT for user response (DO NOT PROCEED)
+7. WAIT for user response (DO NOT PROCEED)
 
-6. Parse response:
-   ├─ IF user selects B or C for Q1 → redirect accordingly
-   └─ IF user selects A for Q1 → store and continue
+8. Parse response and store ALL results:
+   - spec_path = [from Q0/Q1 or $ARGUMENTS]
+   - confirm_choice = [A/B/C from Q1]
+   - execution_mode = [AUTONOMOUS/INTERACTIVE from suffix or Q2]
+   - dispatch_mode = [single/multi_small/multi_large from Q3]
+   - memory_choice = [A/B/C from Q4, or N/A if no memory files]
 
-7. Store results:
-   - spec_path = [confirmed path]
-   - prerequisites_valid = yes
-   - execution_mode = [AUTONOMOUS/INTERACTIVE] (from suffix or Q2 answer)
+9. Handle redirects if needed:
+   - IF confirm_choice == B → Re-prompt with folder selection only
+   - IF confirm_choice == C → Redirect to /spec_kit:plan
 
-8. SET STATUS: ✅ PASSED (Stateless - no .spec-active file created)
+10. Execute background operations based on choices:
+    - IF memory_choice == A: Load most recent memory file
+    - IF memory_choice == B: Load up to 3 recent memory files
+    - IF dispatch_mode is multi_*: Note parallel dispatch will be used
 
-**STOP HERE** - Wait for user to confirm spec folder and select execution mode before continuing.
+11. SET STATUS: ✅ PASSED
 
-⛔ HARD STOP: DO NOT proceed until user explicitly confirms
-⛔ NEVER assume spec folder is correct without validation
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
+
+⛔ HARD STOP: DO NOT proceed until user explicitly answers
+⛔ NEVER assume spec folder is correct without user confirmation
 ⛔ NEVER auto-select execution mode without suffix or explicit choice
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 2 Output:** `spec_path = ________________` | `prerequisites_valid = [yes/no]` | `execution_mode = ________________`
-
----
-
-## 🔒 PHASE 3: DISPATCH MODE SELECTION
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 2 PASSES:
-
-1. DISPLAY dispatch mode options:
-
-   ┌────────────────────────────────────────────────────────────────┐
-   │ **Dispatch Mode** (required):                                  │
-   │                                                                │
-   │ A) Single Agent - Execute with one Opus agent (default)        │
-   │ B) Multi-Agent (1+2) - 1 Opus orchestrator + 2 Sonnet workers  │
-   │ C) Multi-Agent (1+3) - 1 Opus orchestrator + 3 Sonnet workers  │
-   │                                                                │
-   │ Reply with A, B, or C                                          │
-   └────────────────────────────────────────────────────────────────┘
-
-2. WAIT for user response (DO NOT PROCEED)
-
-3. Parse response and store:
-   ├─ "A" or "single" → dispatch_mode = "single"
-   ├─ "B" or "1+2" → dispatch_mode = "multi_small"
-   ├─ "C" or "1+3" → dispatch_mode = "multi_large"
-   └─ Invalid → Re-prompt with options
-
-4. IF dispatch_mode == "multi_small" or "multi_large":
-   ├─ Acknowledge: "Multi-agent mode selected. Workers will be dispatched for parallel implementation."
-   └─ Note: Orchestrator (Opus) coordinates, Workers (Sonnet) execute focused domains
-
-5. SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select dispatch mode before continuing.
-
-⛔ HARD STOP: DO NOT proceed until dispatch mode is selected
-```
-
-**Phase 3 Output:** `dispatch_mode = [single/multi_small/multi_large]`
-
----
-
-## 🔒 PHASE 4: MEMORY CONTEXT LOADING (Conditional)
-
-**STATUS: ☐ BLOCKED / ☐ N/A**
-
-```
-EXECUTE AFTER PHASE 3 PASSES:
-
-1. Check: Does spec_path/memory/ exist AND contain files?
-
-├─ IF memory/ is empty or missing:
-│   └─ SET STATUS: ⏭️ N/A (no memory to load)
-│
-└─ IF memory/ has files:
-    │
-    ├─ ASK user:
-    │   ┌────────────────────────────────────────────────────┐
-    │   │ "Load previous context from this spec folder?"     │
-    │   │                                                    │
-    │   │ A) Load most recent memory file (quick refresh)     │
-    │   │ B) Load all recent files, up to 3 (comprehensive)   │
-    │   │ C) List all files and select specific                │
-    │   │ D) Skip (start fresh, no context)                  │
-    │   └────────────────────────────────────────────────────┘
-    │
-    ├─ WAIT for user response
-    ├─ Execute loading based on choice (use Read tool)
-    ├─ Acknowledge loaded context briefly
-    └─ SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select memory loading option before continuing.
-
-⛔ HARD STOP: DO NOT proceed until STATUS = ✅ PASSED or ⏭️ N/A
-```
-
-**Phase 4 Output:** `memory_loaded = [yes/no]` | `context_summary = ________________`
+**Phase Output:**
+- `spec_path = ________________`
+- `prerequisites_valid = ________________`
+- `execution_mode = ________________`
+- `dispatch_mode = ________________`
+- `memory_loaded = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                       | REQUIRED STATUS   | YOUR STATUS | OUTPUT VALUE                            |
-| --------------------------- | ----------------- | ----------- | --------------------------------------- |
-| PHASE 1: INPUT              | ✅ PASSED          | ______      | spec_folder_input: ______               |
-| PHASE 2: SETUP (Valid+Mode) | ✅ PASSED          | ______      | spec_path: ___ / valid: ___ / mode: ___ |
-| PHASE 3: DISPATCH MODE      | ✅ PASSED          | ______      | dispatch_mode: ______                   |
-| PHASE 4: MEMORY             | ✅ PASSED or ⏭️ N/A | ______      | memory_loaded: ______                   |
+| FIELD               | REQUIRED      | YOUR VALUE | SOURCE                |
+| ------------------- | ------------- | ---------- | --------------------- |
+| spec_path           | ✅ Yes         | ______     | Q0/Q1 or $ARGUMENTS   |
+| prerequisites_valid | ✅ Yes         | ______     | Validation check      |
+| execution_mode      | ✅ Yes         | ______     | Suffix or Q2          |
+| dispatch_mode       | ✅ Yes         | ______     | Q3                    |
+| memory_loaded       | ○ Conditional | ______     | Q4 (if memory exists) |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED or ⏭️ N/A?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Implement" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -239,23 +154,20 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
-- Proceeded without asking user for spec folder (Phase 1)
-- Asked validation confirmation and execution mode as SEPARATE questions instead of consolidated (Phase 2)
-- Started implementation without validating spec folder has required files (Phase 2)
-- Skipped dispatch mode selection (Phase 3)
-- Assumed single-agent mode without explicit user choice (Phase 3)
-- Skipped memory prompt when memory files exist (Phase 4)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Started implementation without validating spec folder has required files
+- Auto-selected dispatch mode without explicit user choice
 - Inferred spec folder from .spec-active or context instead of explicit user input
 - Auto-selected execution mode without suffix or explicit user choice
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 ---
@@ -423,8 +335,8 @@ The implement workflow supports parallel agent dispatch for complex phases. This
 
 This command routes Step 11 (Checklist Verification) to the specialized `@review` agent when available.
 
-| Step | Agent | Fallback | Purpose |
-|------|-------|----------|---------|
+| Step                             | Agent     | Fallback  | Purpose                                           |
+| -------------------------------- | --------- | --------- | ------------------------------------------------- |
 | Step 7 (Completion/Verification) | `@review` | `general` | P0/P1 checklist verification with quality scoring |
 
 ### How Agent Routing Works
@@ -480,11 +392,11 @@ Quality gates enforce minimum standards at key workflow transitions.
 
 ### Gate Configuration
 
-| Gate | Location | Threshold | Blocking |
-|------|----------|-----------|----------|
-| Pre-Implementation | Before Step 6 | 70 | Yes |
-| Mid-Implementation | After Step 6.5 | 65 | No (warning only) |
-| Post-Implementation | Before Step 7 completion | 70 | Yes |
+| Gate                | Location                 | Threshold | Blocking          |
+| ------------------- | ------------------------ | --------- | ----------------- |
+| Pre-Implementation  | Before Step 6            | 70        | Yes               |
+| Mid-Implementation  | After Step 6.5           | 65        | No (warning only) |
+| Post-Implementation | Before Step 7 completion | 70        | Yes               |
 
 ### Gate Behavior
 
@@ -535,19 +447,19 @@ The circuit breaker isolates failing operations to prevent cascading failures.
 
 ### States
 
-| State | Condition | Behavior |
-|-------|-----------|----------|
-| CLOSED | Normal operation | All operations proceed |
-| OPEN | 3+ consecutive failures | Operations fail-fast, skip affected step |
-| HALF-OPEN | After cooldown (30s) | Single test operation allowed |
+| State     | Condition               | Behavior                                 |
+| --------- | ----------------------- | ---------------------------------------- |
+| CLOSED    | Normal operation        | All operations proceed                   |
+| OPEN      | 3+ consecutive failures | Operations fail-fast, skip affected step |
+| HALF-OPEN | After cooldown (30s)    | Single test operation allowed            |
 
 ### Configuration
 
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| failure_threshold | 3 | Failures before OPEN state |
-| cooldown_seconds | 30 | Time before HALF-OPEN |
-| success_to_close | 1 | Successes in HALF-OPEN to return to CLOSED |
+| Parameter         | Value | Description                                |
+| ----------------- | ----- | ------------------------------------------ |
+| failure_threshold | 3     | Failures before OPEN state                 |
+| cooldown_seconds  | 30    | Time before HALF-OPEN                      |
+| success_to_close  | 1     | Successes in HALF-OPEN to return to CLOSED |
 
 ### Behavior by Step
 
@@ -634,12 +546,12 @@ This command is part of the SpecKit workflow:
 
 After implementation completes, suggest relevant next steps:
 
-| Condition | Suggested Command | Reason |
-|-----------|-------------------|--------|
-| Implementation complete | Verify in browser | Test functionality works |
-| Need to save progress | `/memory:save [spec-folder-path]` | Preserve implementation context |
-| Ending session | `/spec_kit:handover [spec-folder-path]` | Create continuation document |
-| Found bugs during testing | `/spec_kit:debug [spec-folder-path]` | Delegate debugging to fresh agent |
-| Ready for next feature | `/spec_kit:complete [feature-description]` | Start new workflow |
+| Condition                 | Suggested Command                          | Reason                            |
+| ------------------------- | ------------------------------------------ | --------------------------------- |
+| Implementation complete   | Verify in browser                          | Test functionality works          |
+| Need to save progress     | `/memory:save [spec-folder-path]`          | Preserve implementation context   |
+| Ending session            | `/spec_kit:handover [spec-folder-path]`    | Create continuation document      |
+| Found bugs during testing | `/spec_kit:debug [spec-folder-path]`       | Delegate debugging to fresh agent |
+| Ready for next feature    | `/spec_kit:complete [feature-description]` | Start new workflow                |
 
 **ALWAYS** end with: "What would you like to do next?"

--- a/.opencode/command/spec_kit/plan.md
+++ b/.opencode/command/spec_kit/plan.md
@@ -4,203 +4,122 @@ argument-hint: "<feature-description> [:auto|:confirm]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** This workflow requires 2-3 user interactions (down from 4).
+**Round-trip optimization:** This workflow requires only 1 user interaction (all questions asked together).
 
 ---
 
-## 🔒 PHASE 1: INPUT COLLECTION
+## 🔒 UNIFIED SETUP PHASE
+
+**⚠️ FIRST MESSAGE PROTOCOL**: This consolidated prompt MUST be your FIRST response if the command is invoked. No analysis, no tool calls - ask ALL questions immediately in ONE prompt, then wait.
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
-
-├─ IF $ARGUMENTS is empty, undefined, or whitespace-only (ignoring :auto/:confirm flags):
-│   │
-│   ├─ ASK user: "What feature would you like to plan?"
-│   ├─ WAIT for user response (DO NOT PROCEED)
-│   ├─ Store response as: feature_description
-│   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-│
-└─ IF $ARGUMENTS contains content:
-    ├─ Store as: feature_description
-    └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-
-**STOP HERE** - Wait for user to provide the feature description before continuing.
-
-⛔ HARD STOP: DO NOT read past this phase until STATUS = ✅ PASSED
-⛔ NEVER infer features from context, screenshots, or conversation history
-```
-
-**Phase 1 Output:** `feature_description = ________________`
-
----
-
-## 🔒 PHASE 2: CONSOLIDATED SETUP (Spec Folder + Execution Mode)
-
-**⚠️ FIRST MESSAGE PROTOCOL**: This phase MUST be your FIRST response if the command is invoked. No analysis, no tool calls - ask the consolidated question immediately, then wait.
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 1 PASSES:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
 1. CHECK for mode suffix in command invocation:
-   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, still ask Q1)
-   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, still ask Q1)
-   └─ No suffix → execution_mode = "ASK" (include Q2 in consolidated prompt)
+   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, omit Q2)
+   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, omit Q2)
+   └─ No suffix → execution_mode = "ASK" (include Q2 in prompt)
 
-2. Search for related spec folders:
+2. CHECK if $ARGUMENTS contains a feature description:
+   ├─ IF $ARGUMENTS has content (ignoring :auto/:confirm) → feature_description = $ARGUMENTS, omit Q0
+   └─ IF $ARGUMENTS is empty → include Q0 in prompt
+
+3. Search for related spec folders:
    $ ls -d specs/*/ 2>/dev/null | tail -10
 
-3. ASK user with CONSOLIDATED prompt (bundle applicable questions):
+4. Determine if memory loading question is needed:
+   - Will be asked ONLY if user selects A or C for spec folder AND memory/ has files
+   - Include Q4 placeholder with note "(if using existing spec with memory files)"
+
+5. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
 
    ┌────────────────────────────────────────────────────────────────┐
    │ **Before proceeding, please answer:**                          │
    │                                                                │
-   │ **1. Spec Folder** (required):                                 │
+   │ **Q0. Feature Description** (if not provided in command):      │
+   │    What feature would you like to plan?                        │
+   │                                                                │
+   │ **Q1. Spec Folder** (required):                                │
    │    A) Use existing: [suggest if related found]                 │
-   │    B) Create new spec folder                                   │
+   │    B) Create new spec folder: specs/[###]-[feature-slug]/      │
    │    C) Update related spec: [if partial match found]            │
    │    D) Skip documentation                                       │
    │                                                                │
-   │ **2. Execution Mode** (if no :auto/:confirm suffix):             │
-   │    A) Autonomous - Execute all steps without approval          │
+   │ **Q2. Execution Mode** (if no :auto/:confirm suffix):            │
+   │    A) Autonomous - Execute all 7 steps without approval        │
    │    B) Interactive - Pause at each step for approval            │
    │                                                                │
-   │ Reply with choices, e.g.: "B, A" or "A" (if mode pre-set)      │
+   │ **Q3. Dispatch Mode** (required):                              │
+   │    A) Single Agent - Execute with one agent (Recommended)      │
+   │    B) Multi-Agent (1+2) - 1 orchestrator + 2 workers           │
+   │    C) Multi-Agent (1+3) - 1 orchestrator + 3 workers           │
+   │                                                                │
+   │ **Q4. Memory Context** (if using existing spec with memory/):  │
+   │    A) Load most recent memory file                              │
+   │    B) Load all recent files, up to 3                            │
+   │    C) Skip (start fresh)                                       │
+   │                                                                │
+   │ Reply with answers, e.g.: "B, A, A" or "Add auth, B, A, A, C"  │
    └────────────────────────────────────────────────────────────────┘
 
-4. WAIT for user response (DO NOT PROCEED)
+6. WAIT for user response (DO NOT PROCEED)
 
-5. Parse response and store results:
-   - spec_choice = [A/B/C/D] (first answer)
-   - spec_path = [path or null if D]
-   - execution_mode = [AUTONOMOUS/INTERACTIVE] (from suffix or second answer)
+7. Parse response and store ALL results:
+   - feature_description = [from Q0 or $ARGUMENTS]
+   - spec_choice = [A/B/C/D from Q1]
+   - spec_path = [derived path or null if D]
+   - execution_mode = [AUTONOMOUS/INTERACTIVE from suffix or Q2]
+   - dispatch_mode = [single/multi_small/multi_large from Q3]
+   - memory_choice = [A/B/C from Q4, or N/A if not applicable]
 
-6. SET STATUS: ✅ PASSED (Stateless - no .spec-active file created)
+8. Execute background operations based on choices:
+   - IF memory_choice == A: Load most recent memory file
+   - IF memory_choice == B: Load up to 3 recent memory files
+   - IF dispatch_mode is multi_*: Note parallel dispatch will be used
 
-**STOP HERE** - Wait for user to select A/B/C/D and execution mode before continuing.
+9. SET STATUS: ✅ PASSED
+
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
 
 ⛔ HARD STOP: DO NOT proceed until user explicitly answers
 ⛔ NEVER auto-create spec folders without user confirmation
 ⛔ NEVER auto-select execution mode without suffix or explicit choice
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 2 Output:** `spec_choice = ___` | `spec_path = ________________` | `execution_mode = ________________`
-
----
-
-## 🔒 PHASE 3: DISPATCH MODE SELECTION
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 2 PASSES:
-
-1. DISPLAY dispatch mode options:
-
-   ┌────────────────────────────────────────────────────────────────┐
-   │ **Dispatch Mode** (required):                                  │
-   │                                                                │
-   │ A) Single Agent - Execute with one Opus agent (default)        │
-   │ B) Multi-Agent (1+2) - 1 Opus orchestrator + 2 Sonnet workers  │
-   │ C) Multi-Agent (1+3) - 1 Opus orchestrator + 3 Sonnet workers  │
-   │                                                                │
-   │ Reply with A, B, or C                                          │
-   └────────────────────────────────────────────────────────────────┘
-
-2. WAIT for user response (DO NOT PROCEED)
-
-3. Parse response and store:
-   ├─ "A" or "single" → dispatch_mode = "single"
-   ├─ "B" or "1+2" → dispatch_mode = "multi_small"
-   ├─ "C" or "1+3" → dispatch_mode = "multi_large"
-   └─ Invalid → Re-prompt with options
-
-4. IF dispatch_mode == "multi_small" or "multi_large":
-   ├─ Acknowledge: "Multi-agent mode selected. Workers will be dispatched for parallel exploration."
-   └─ Note: Orchestrator (Opus) coordinates, Workers (Sonnet) execute focused domains
-
-5. SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select dispatch mode before continuing.
-
-⛔ HARD STOP: DO NOT proceed until dispatch mode is selected
-```
-
-**Phase 3 Output:** `dispatch_mode = [single/multi_small/multi_large]`
-
----
-
-## 🔒 PHASE 4: MEMORY CONTEXT LOADING (Conditional)
-
-**STATUS: ☐ BLOCKED / ☐ N/A**
-
-```
-EXECUTE AFTER PHASE 3 PASSES:
-
-CHECK spec_choice value from Phase 2:
-
-├─ IF spec_choice == D (Skip):
-│   └─ SET STATUS: ⏭️ N/A (no spec folder, no memory)
-│
-├─ IF spec_choice == B (Create new):
-│   └─ SET STATUS: ⏭️ N/A (new folder has no memory)
-│
-└─ IF spec_choice == A or C (Use existing):
-    │
-    ├─ Check: Does spec_path/memory/ exist AND contain files?
-    │
-    ├─ IF memory/ is empty or missing:
-    │   └─ SET STATUS: ⏭️ N/A (no memory to load)
-    │
-    └─ IF memory/ has files:
-        │
-        ├─ ASK user:
-        │   ┌────────────────────────────────────────────────────┐
-        │   │ "Load previous context from this spec folder?"     │
-        │   │                                                    │
-        │   │ A) Load most recent memory file (quick refresh)     │
-        │   │ B) Load all recent files, up to 3 (comprehensive)   │
-        │   │ C) List all files and select specific                │
-        │   │ D) Skip (start fresh, no context)                  │
-        │   └────────────────────────────────────────────────────┘
-        │
-        ├─ WAIT for user response
-        ├─ Execute loading based on choice (use Read tool)
-        ├─ Acknowledge loaded context briefly
-        └─ SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select memory loading option before continuing.
-
-⛔ HARD STOP: DO NOT proceed until STATUS = ✅ PASSED or ⏭️ N/A
-```
-
-**Phase 4 Output:** `memory_loaded = [yes/no]` | `context_summary = ________________`
+**Phase Output:**
+- `feature_description = ________________`
+- `spec_choice = ___` | `spec_path = ________________`
+- `execution_mode = ________________`
+- `dispatch_mode = ________________`
+- `memory_loaded = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                      | REQUIRED STATUS   | YOUR STATUS | OUTPUT VALUE                                  |
-| -------------------------- | ----------------- | ----------- | --------------------------------------------- |
-| PHASE 1: INPUT             | ✅ PASSED          | ______      | feature_description: ______                   |
-| PHASE 2: SETUP (Spec+Mode) | ✅ PASSED          | ______      | spec_choice: ___ / spec_path: ___ / mode: ___ |
-| PHASE 3: DISPATCH MODE     | ✅ PASSED          | ______      | dispatch_mode: ______                         |
-| PHASE 4: MEMORY            | ✅ PASSED or ⏭️ N/A | ______      | memory_loaded: ______                         |
+| FIELD               | REQUIRED      | YOUR VALUE | SOURCE                |
+| ------------------- | ------------- | ---------- | --------------------- |
+| feature_description | ✅ Yes         | ______     | Q0 or $ARGUMENTS      |
+| spec_choice         | ✅ Yes         | ______     | Q1                    |
+| spec_path           | ○ Conditional | ______     | Derived from Q1       |
+| execution_mode      | ✅ Yes         | ______     | Suffix or Q2          |
+| dispatch_mode       | ✅ Yes         | ______     | Q3                    |
+| memory_loaded       | ○ Conditional | ______     | Q4 (if existing spec) |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED or ⏭️ N/A?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Plan" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -208,23 +127,21 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
-- Proceeded without asking user for feature description (Phase 1)
-- Asked spec folder and execution mode as SEPARATE questions instead of consolidated (Phase 2)
-- Auto-created or assumed a spec folder without A/B/C/D choice (Phase 2)
-- Skipped dispatch mode selection (Phase 3)
-- Assumed single-agent mode without explicit user choice (Phase 3)
-- Skipped memory prompt when using existing folder with memory files (Phase 4)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Proceeded without asking user for feature description when not in $ARGUMENTS
+- Auto-created or assumed a spec folder without user confirmation
+- Auto-selected dispatch mode without explicit user choice
 - Inferred feature from context instead of explicit user input
 - Auto-selected execution mode without suffix or explicit user choice
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 > **Cross-reference**: These mandatory phases implement AGENTS.md Section 2 "Gate 3: Spec Folder Question" and "First Message Protocol". The canonical gate definitions are in AGENTS.md.
@@ -376,7 +293,7 @@ This workflow supports smart parallel sub-agent dispatch for eligible phases usi
 
 ### Planning Step: 4-Agent Parallel Exploration (Automatic)
 
-The Planning step automatically dispatches 4 Sonnet agents in parallel via the Task tool:
+The Planning step automatically dispatches 4 agents in parallel via the Task tool:
 
 1. **Architecture Explorer** - Project structure, entry points, component connections
 2. **Feature Explorer** - Similar features, related patterns
@@ -402,19 +319,18 @@ After agents return, hypotheses are verified by reading identified files and bui
 
 This command routes Step 3 (Specification) to the specialized `@speckit` agent when available.
 
-| Step | Agent | Model | Fallback | Purpose |
-|------|-------|-------|----------|---------|
-| Step 3 (Specification) | `@speckit` | **sonnet** | `general` | Template-first spec folder creation with validation |
+| Step                   | Agent      | Fallback  | Purpose                                             |
+| ---------------------- | ---------- | --------- | --------------------------------------------------- |
+| Step 3 (Specification) | `@speckit` | `general` | Template-first spec folder creation with validation |
 
 ### Model Preference
 
-**Default**: Sonnet (cost-effective, fast)
-**Override**: Use Opus ONLY when user explicitly requests ("use opus", "use most capable model")
+Model selection is handled automatically by the system based on task complexity.
 
 ### How Agent Routing Works
 
 1. **Detection**: When Step 3 is reached, the system checks if `@speckit` agent is available
-2. **Dispatch**: If available, dispatches to `@speckit` agent with `model: sonnet` and feature description
+2. **Dispatch**: If available, dispatches to `@speckit` agent with feature description
 3. **Fallback**: If agent unavailable, falls back to `subagent_type: "general-purpose"` (Claude Code) or `"general"` (OpenCode) with warning
 4. **Output**: Agent returns confirmation of created files with validation status
 
@@ -451,11 +367,11 @@ Quality gates enforce minimum standards at workflow checkpoints.
 
 ### Gate Configuration
 
-| Gate Type | Trigger Point | Threshold | Behavior |
-|-----------|---------------|-----------|----------|
-| Pre-execution | Before Step 1 starts | 70 | Validates inputs and prerequisites |
-| Mid-execution | After Step 3 (Specification) | 70 | Validates spec.md quality |
-| Post-execution | After Step 7 (Handover Check) | 70 | Validates all artifacts complete |
+| Gate Type      | Trigger Point                 | Threshold | Behavior                           |
+| -------------- | ----------------------------- | --------- | ---------------------------------- |
+| Pre-execution  | Before Step 1 starts          | 70        | Validates inputs and prerequisites |
+| Mid-execution  | After Step 3 (Specification)  | 70        | Validates spec.md quality          |
+| Post-execution | After Step 7 (Handover Check) | 70        | Validates all artifacts complete   |
 
 ### Gate Behavior
 
@@ -487,18 +403,18 @@ Circuit breaker pattern prevents cascading failures during workflow execution.
 
 ### States
 
-| State | Description | Behavior |
-|-------|-------------|----------|
-| CLOSED | Normal operation | Errors tracked, workflow continues |
-| OPEN | Failure threshold exceeded | Workflow halted, recovery required |
-| HALF-OPEN | Recovery attempted | Single retry allowed, success resets to CLOSED |
+| State     | Description                | Behavior                                       |
+| --------- | -------------------------- | ---------------------------------------------- |
+| CLOSED    | Normal operation           | Errors tracked, workflow continues             |
+| OPEN      | Failure threshold exceeded | Workflow halted, recovery required             |
+| HALF-OPEN | Recovery attempted         | Single retry allowed, success resets to CLOSED |
 
 ### Configuration
 
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| failure_threshold | 3 | Consecutive failures before OPEN state |
-| recovery_timeout | 60 | Seconds before attempting HALF-OPEN |
+| Parameter         | Value | Description                            |
+| ----------------- | ----- | -------------------------------------- |
+| failure_threshold | 3     | Consecutive failures before OPEN state |
+| recovery_timeout  | 60    | Seconds before attempting HALF-OPEN    |
 
 ### Tracked Errors
 

--- a/.opencode/command/spec_kit/research.md
+++ b/.opencode/command/spec_kit/research.md
@@ -4,234 +4,131 @@ argument-hint: "<research-topic> [:auto|:confirm]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, WebFetch, WebSearch
 ---
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** This workflow requires 3-4 user interactions (spec folder, dispatch mode, prior work, memory).
+**Round-trip optimization:** This workflow requires only 1 user interaction (all questions asked together).
 
 ---
 
-## 🔒 PHASE 1: INPUT COLLECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE THIS CHECK FIRST:
-
-├─ IF $ARGUMENTS is empty, undefined, or whitespace-only (ignoring :auto/:confirm flags):
-│   │
-│   ├─ ASK user: "What topic would you like to research?"
-│   ├─ WAIT for user response (DO NOT PROCEED)
-│   ├─ Store response as: research_topic
-│   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-│
-└─ IF $ARGUMENTS contains content:
-    ├─ Store as: research_topic
-    └─ SET STATUS: ✅ PASSED → Proceed to PHASE 2
-
-**STOP HERE** - Wait for user to provide the research topic before continuing.
-
-⛔ HARD STOP: DO NOT read past this phase until STATUS = ✅ PASSED
-⛔ NEVER infer topics from context, screenshots, or conversation history
-```
-
-**Phase 1 Output:** `research_topic = ________________`
-
----
-
-## 🔒 PHASE 2: CONSOLIDATED SETUP (Spec Folder + Execution Mode)
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 1 PASSES:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
 1. CHECK for mode suffix in command invocation:
-   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, still ask Q1)
-   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, still ask Q1)
-   └─ No suffix → execution_mode = "ASK" (include Q2 in consolidated prompt)
+   ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS" (pre-set, omit Q2)
+   ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE" (pre-set, omit Q2)
+   └─ No suffix → execution_mode = "ASK" (include Q2 in prompt)
 
-2. Search for related spec folders:
+2. CHECK if $ARGUMENTS contains a research topic:
+   ├─ IF $ARGUMENTS has content (ignoring :auto/:confirm) → research_topic = $ARGUMENTS, omit Q0
+   └─ IF $ARGUMENTS is empty → include Q0 in prompt
+
+3. Search for related spec folders:
    $ ls -d specs/*/ 2>/dev/null | tail -10
 
-3. ASK user with CONSOLIDATED prompt (bundle applicable questions):
+4. Search for prior work (background, no user wait):
+   - memory_match_triggers(prompt=research_topic OR "research")
+   - memory_search(query=research_topic OR "research", includeConstitutional=true)
+   - Store: prior_work_found = [yes/no], prior_work_count = [N]
+
+5. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
 
    ┌────────────────────────────────────────────────────────────────┐
    │ **Before proceeding, please answer:**                          │
    │                                                                │
-   │ **1. Spec Folder** (required):                                 │
+   │ **Q0. Research Topic** (if not provided in command):           │
+   │    What topic would you like to research?                      │
+   │                                                                │
+   │ **Q1. Spec Folder** (required):                                │
    │    A) Use existing: [suggest if related found]                 │
    │    B) Create new spec folder: specs/[###]-[topic-slug]/        │
    │    C) Update related spec: [if partial match found]            │
    │    D) Skip documentation (research only, no artifacts)         │
    │                                                                │
-   │ **2. Execution Mode** (if no :auto/:confirm suffix):             │
+   │ **Q2. Execution Mode** (if no :auto/:confirm suffix):            │
    │    A) Autonomous - Execute all 9 steps without approval        │
    │    B) Interactive - Pause at each step for approval            │
    │                                                                │
-   │ Reply with choices, e.g.: "B, A" or "A" (if mode pre-set)      │
+   │ **Q3. Dispatch Mode** (required):                              │
+   │    A) Single Agent - Execute with one agent (Recommended)      │
+   │    B) Multi-Agent (1+2) - 1 orchestrator + 2 workers           │
+   │    C) Multi-Agent (1+3) - 1 orchestrator + 3 workers           │
+   │                                                                │
+   │ **Q4. Prior Work** (if [N] related memories found):            │
+   │    A) Load all matches (comprehensive context)                 │
+   │    B) Load constitutional only (foundational rules)            │
+   │    C) Skip (start fresh)                                       │
+   │                                                                │
+   │ **Q5. Memory Context** (if using existing spec with memory/):  │
+   │    A) Load most recent memory file                              │
+   │    B) Load all recent files, up to 3                           │
+   │    C) Skip (start fresh)                                       │
+   │                                                                │
+   │ Reply with answers, e.g.: "B, A, A" or "AI chat, B, A, A, C"   │
    └────────────────────────────────────────────────────────────────┘
 
-4. WAIT for user response (DO NOT PROCEED)
+6. WAIT for user response (DO NOT PROCEED)
 
-5. Parse response and store results:
-   - spec_choice = [A/B/C/D] (first answer)
-   - spec_path = [path or null if D]
-   - execution_mode = [AUTONOMOUS/INTERACTIVE] (from suffix or second answer)
+7. Parse response and store ALL results:
+   - research_topic = [from Q0 or $ARGUMENTS]
+   - spec_choice = [A/B/C/D from Q1]
+   - spec_path = [derived path or null if D]
+   - execution_mode = [AUTONOMOUS/INTERACTIVE from suffix or Q2]
+   - dispatch_mode = [single/multi_small/multi_large from Q3]
+   - prior_work_choice = [A/B/C from Q4, or N/A if no matches]
+   - memory_choice = [A/B/C from Q5, or N/A if not applicable]
 
-6. UPDATE SPEC MARKER:
-   ├─ Stateless architecture - no .spec-active marker file
-   └─ Spec folder is passed via CLI argument
+8. Execute background operations based on choices:
+   - IF prior_work_choice == A: Load all prior work matches
+   - IF prior_work_choice == B: Load constitutional only
+   - IF memory_choice == A: Load most recent memory file
+   - IF memory_choice == B: Load up to 3 recent memory files
+   - IF dispatch_mode is multi_*: Note parallel dispatch will be used
 
-7. SET STATUS: ✅ PASSED
+9. SET STATUS: ✅ PASSED
 
-**STOP HERE** - Wait for user to select A/B/C/D and execution mode before continuing.
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
 
 ⛔ HARD STOP: DO NOT proceed until user explicitly answers
 ⛔ NEVER auto-create spec folders without user confirmation
 ⛔ NEVER auto-select execution mode without suffix or explicit choice
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 2 Output:** `spec_choice = ___` | `spec_path = ________________` | `execution_mode = ________________`
-
----
-
-## 🔒 PHASE 3: DISPATCH MODE SELECTION
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE AFTER PHASE 2 PASSES:
-
-1. DISPLAY dispatch mode options:
-
-   ┌────────────────────────────────────────────────────────────────┐
-   │ **Dispatch Mode** (required):                                  │
-   │                                                                │
-   │ A) Single Agent - Execute with one Opus agent (default)        │
-   │ B) Multi-Agent (1+2) - 1 Opus orchestrator + 2 Sonnet workers  │
-   │ C) Multi-Agent (1+3) - 1 Opus orchestrator + 3 Sonnet workers  │
-   │                                                                │
-   │ Reply with A, B, or C                                          │
-   └────────────────────────────────────────────────────────────────┘
-
-2. WAIT for user response (DO NOT PROCEED)
-
-3. Parse response and store:
-   ├─ "A" or "single" → dispatch_mode = "single"
-   ├─ "B" or "1+2" → dispatch_mode = "multi_small"
-   ├─ "C" or "1+3" → dispatch_mode = "multi_large"
-   └─ Invalid → Re-prompt with options
-
-4. IF dispatch_mode == "multi_small" or "multi_large":
-   ├─ Acknowledge: "Multi-agent mode selected. Workers will be dispatched for parallel research."
-   └─ Note: Orchestrator (Opus) coordinates, Workers (Sonnet) execute focused domains
-
-5. SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select dispatch mode before continuing.
-
-⛔ HARD STOP: DO NOT proceed until dispatch mode is selected
-```
-
-**Phase 3 Output:** `dispatch_mode = [single/multi_small/multi_large]`
-
----
-
-## 🔒 PHASE 4: PRIOR WORK SEARCH (Conditional)
-
-**STATUS: ☐ AUTO-EXECUTE**
-
-```
-EXECUTE AFTER PHASE 3 PASSES:
-
-1. Call memory_match_triggers(prompt=research_topic) for fast keyword match
-2. Call memory_search(query=research_topic, includeConstitutional=true) for semantic search
-3. IF matches found:
-   ├─ Display: "Found [N] related memories from prior research"
-   ├─ ASK user:
-   │   ┌────────────────────────────────────────────────────┐
-   │   │ "Load related prior work?"                         │
-   │   │                                                    │
-   │   │ A) Load all matches (comprehensive context)        │
-   │   │ B) Load constitutional only (foundational rules)   │
-   │   │ C) Skip (start fresh)                              │
-   │   └────────────────────────────────────────────────────┘
-   └─ SET STATUS: ✅ PASSED
-4. IF no matches found:
-   └─ SET STATUS: ⏭️ N/A (no prior work)
-
-⛔ Constitutional tier memories are ALWAYS loaded regardless of choice (they surface automatically with similarity: 100)
-```
-
----
-
-## 🔒 PHASE 5: MEMORY CONTEXT LOADING (Conditional)
-
-**STATUS: ☐ BLOCKED / ☐ N/A**
-
-```
-EXECUTE AFTER PHASE 4 PASSES:
-
-CHECK spec_choice value from Phase 2:
-
-├─ IF spec_choice == D (Skip):
-│   └─ SET STATUS: ⏭️ N/A (no spec folder, no memory)
-│
-├─ IF spec_choice == B (Create new):
-│   └─ SET STATUS: ⏭️ N/A (new folder has no memory)
-│
-└─ IF spec_choice == A or C (Use existing):
-    │
-    ├─ Check: Does spec_path/memory/ exist AND contain files?
-    │
-    ├─ IF memory/ is empty or missing:
-    │   └─ SET STATUS: ⏭️ N/A (no memory to load)
-    │
-    └─ IF memory/ has files:
-        │
-        ├─ ASK user:
-        │   ┌────────────────────────────────────────────────────┐
-        │   │ "Load previous context from this spec folder?"     │
-        │   │                                                    │
-        │   │ A) Load most recent memory file (quick refresh)     │
-        │   │ B) Load all recent files, up to 3 (comprehensive)   │
-        │   │ C) List all files and select specific                │
-        │   │ D) Skip (start fresh, no context)                  │
-        │   └────────────────────────────────────────────────────┘
-        │
-        ├─ WAIT for user response
-        ├─ Execute loading based on choice (use Read tool)
-        ├─ Acknowledge loaded context briefly
-        └─ SET STATUS: ✅ PASSED
-
-**STOP HERE** - Wait for user to select memory loading option before continuing.
-
-⛔ HARD STOP: DO NOT proceed until STATUS = ✅ PASSED or ⏭️ N/A
-```
-
-**Phase 5 Output:** `memory_loaded = [yes/no]` | `context_summary = ________________`
+**Phase Output:**
+- `research_topic = ________________`
+- `spec_choice = ___` | `spec_path = ________________`
+- `execution_mode = ________________`
+- `dispatch_mode = ________________`
+- `prior_work_loaded = ________________`
+- `memory_loaded = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                      | REQUIRED STATUS   | YOUR STATUS | OUTPUT VALUE                                  |
-| -------------------------- | ----------------- | ----------- | --------------------------------------------- |
-| PHASE 1: INPUT             | ✅ PASSED          | ______      | research_topic: ______                        |
-| PHASE 2: SETUP (Spec+Mode) | ✅ PASSED          | ______      | spec_choice: ___ / spec_path: ___ / mode: ___ |
-| PHASE 3: DISPATCH MODE     | ✅ PASSED          | ______      | dispatch_mode: ______                         |
-| PHASE 4: PRIOR WORK        | ✅ PASSED or ⏭️ N/A | ______      | prior_work_loaded: ______                     |
-| PHASE 5: MEMORY            | ✅ PASSED or ⏭️ N/A | ______      | memory_loaded: ______                         |
+| FIELD             | REQUIRED      | YOUR VALUE | SOURCE                |
+| ----------------- | ------------- | ---------- | --------------------- |
+| research_topic    | ✅ Yes         | ______     | Q0 or $ARGUMENTS      |
+| spec_choice       | ✅ Yes         | ______     | Q1                    |
+| spec_path         | ○ Conditional | ______     | Derived from Q1       |
+| execution_mode    | ✅ Yes         | ______     | Suffix or Q2          |
+| dispatch_mode     | ✅ Yes         | ______     | Q3                    |
+| prior_work_loaded | ○ Conditional | ______     | Q4 (if matches found) |
+| memory_loaded     | ○ Conditional | ______     | Q5 (if existing spec) |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED or ⏭️ N/A?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Research" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -239,23 +136,21 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
-- Proceeded without asking user for research topic (Phase 1)
-- Asked spec folder and execution mode as SEPARATE questions instead of consolidated (Phase 2)
-- Auto-created or assumed a spec folder without A/B/C/D choice (Phase 2)
-- Skipped dispatch mode selection (Phase 3)
-- Assumed single-agent mode without explicit user choice (Phase 3)
-- Skipped memory prompt when using existing folder with memory files (Phase 5)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Proceeded without asking user for research topic when not in $ARGUMENTS
+- Auto-created or assumed a spec folder without user confirmation
+- Auto-selected dispatch mode without explicit user choice
 - Inferred topic from context instead of explicit user input
 - Auto-selected execution mode without suffix or explicit user choice
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 ---
@@ -317,11 +212,11 @@ $ARGUMENTS
 
 ### Execution Mode Behaviors
 
-| Mode        | Invocation              | Behavior                                          |
-| ----------- | ----------------------- | ------------------------------------------------- |
-| `:auto`     | `/spec_kit:research:auto "topic"` | Execute all 9 steps without approval gates |
-| `:confirm`  | `/spec_kit:research:confirm "topic"` | Pause at each step for user approval |
-| (default)   | `/spec_kit:research "topic"` | Ask user to choose mode during Phase 2 |
+| Mode       | Invocation                           | Behavior                                   |
+| ---------- | ------------------------------------ | ------------------------------------------ |
+| `:auto`    | `/spec_kit:research:auto "topic"`    | Execute all 9 steps without approval gates |
+| `:confirm` | `/spec_kit:research:confirm "topic"` | Pause at each step for user approval       |
+| (default)  | `/spec_kit:research "topic"`         | Ask user to choose mode during Phase 2     |
 
 ### Mode Examples
 
@@ -364,13 +259,13 @@ Behavior:
 
 ### Mode Selection Guidance
 
-| Scenario                                      | Recommended Mode |
-| --------------------------------------------- | ---------------- |
-| Quick research, known domain                  | `:auto`          |
-| Complex topic, need validation at each step   | `:confirm`       |
-| First time researching unfamiliar area        | `:confirm`       |
-| Re-running research with minor scope changes  | `:auto`          |
-| Multi-stakeholder decision requiring review   | `:confirm`       |
+| Scenario                                     | Recommended Mode |
+| -------------------------------------------- | ---------------- |
+| Quick research, known domain                 | `:auto`          |
+| Complex topic, need validation at each step  | `:confirm`       |
+| First time researching unfamiliar area       | `:confirm`       |
+| Re-running research with minor scope changes | `:auto`          |
+| Multi-stakeholder decision requiring review  | `:confirm`       |
 
 ---
 
@@ -534,12 +429,12 @@ Memory integration ensures research builds on prior work and preserves findings 
 
 ### Memory Search Patterns for Research
 
-| Research Phase      | Memory Query                                           | Purpose                       |
-| ------------------- | ------------------------------------------------------ | ----------------------------- |
-| Before Step 1       | `memory_search({ query: topic })`                      | Find prior related research   |
-| During Step 3       | `memory_search({ anchors: ['architecture'] })`         | Existing patterns/decisions   |
-| During Step 4       | `memory_search({ anchors: ['external-research'] })`    | Prior external source findings |
-| After Step 9        | `generate-context.js [spec-folder]`                    | Preserve current research     |
+| Research Phase | Memory Query                                        | Purpose                        |
+| -------------- | --------------------------------------------------- | ------------------------------ |
+| Before Step 1  | `memory_search({ query: topic })`                   | Find prior related research    |
+| During Step 3  | `memory_search({ anchors: ['architecture'] })`      | Existing patterns/decisions    |
+| During Step 4  | `memory_search({ anchors: ['external-research'] })` | Prior external source findings |
+| After Step 9   | `generate-context.js [spec-folder]`                 | Preserve current research      |
 
 ### Memory Integration Example
 
@@ -575,8 +470,8 @@ Research Topic: "WebSocket implementation patterns"
 
 This command routes Steps 3-7 to the specialized `@research` agent when available.
 
-| Step | Agent | Fallback | Purpose |
-|------|-------|----------|---------|
+| Step                      | Agent       | Fallback  | Purpose                                              |
+| ------------------------- | ----------- | --------- | ---------------------------------------------------- |
 | Steps 3-7 (Investigation) | `@research` | `general` | 9-step research workflow with comprehensive findings |
 
 ### How Agent Routing Works
@@ -622,11 +517,11 @@ Quality gates enforce validation at critical workflow stages to ensure research 
 
 ### Gate Configuration
 
-| Gate           | Location         | Purpose                                      | Threshold |
-| -------------- | ---------------- | -------------------------------------------- | --------- |
-| Pre-execution  | Before Step 1    | Validate inputs and prerequisites            | Score ≥70 |
-| Mid-execution  | After Step 5     | Verify research progress and quality         | Score ≥70 |
-| Post-execution | After Step 9     | Confirm all deliverables meet standards      | Score ≥70 |
+| Gate           | Location      | Purpose                                 | Threshold |
+| -------------- | ------------- | --------------------------------------- | --------- |
+| Pre-execution  | Before Step 1 | Validate inputs and prerequisites       | Score ≥70 |
+| Mid-execution  | After Step 5  | Verify research progress and quality    | Score ≥70 |
+| Post-execution | After Step 9  | Confirm all deliverables meet standards | Score ≥70 |
 
 ### Gate Behavior
 
@@ -668,11 +563,11 @@ The circuit breaker prevents cascading failures by isolating problematic operati
 
 ### States
 
-| State     | Behavior                                             | Transition Trigger              |
-| --------- | ---------------------------------------------------- | ------------------------------- |
-| CLOSED    | Normal operation, all requests processed             | Default state                   |
-| OPEN      | All requests blocked, fast-fail immediately          | failure_threshold (3) reached   |
-| HALF-OPEN | Limited requests allowed to test recovery            | recovery_timeout (60s) elapsed  |
+| State     | Behavior                                    | Transition Trigger             |
+| --------- | ------------------------------------------- | ------------------------------ |
+| CLOSED    | Normal operation, all requests processed    | Default state                  |
+| OPEN      | All requests blocked, fast-fail immediately | failure_threshold (3) reached  |
+| HALF-OPEN | Limited requests allowed to test recovery   | recovery_timeout (60s) elapsed |
 
 ### Configuration
 
@@ -861,12 +756,12 @@ This command is part of the SpecKit workflow:
 
 After research completes, suggest relevant next steps:
 
-| Condition | Suggested Command | Reason |
-|-----------|-------------------|--------|
-| Research complete, ready to plan | `/spec_kit:plan [feature-description]` | Use findings to create spec and plan |
-| Need more investigation | `/spec_kit:research [new-topic]` | Deeper dive on specific area |
-| Research reveals blockers | Document in research.md | Capture constraints before planning |
-| Need to pause work | `/spec_kit:handover [spec-folder-path]` | Save context for later |
-| Want to save context | `/memory:save [spec-folder-path]` | Preserve research findings |
+| Condition                        | Suggested Command                       | Reason                               |
+| -------------------------------- | --------------------------------------- | ------------------------------------ |
+| Research complete, ready to plan | `/spec_kit:plan [feature-description]`  | Use findings to create spec and plan |
+| Need more investigation          | `/spec_kit:research [new-topic]`        | Deeper dive on specific area         |
+| Research reveals blockers        | Document in research.md                 | Capture constraints before planning  |
+| Need to pause work               | `/spec_kit:handover [spec-folder-path]` | Save context for later               |
+| Want to save context             | `/memory:save [spec-folder-path]`       | Preserve research findings           |
 
 **ALWAYS** end with: "What would you like to do next?"

--- a/.opencode/command/spec_kit/resume.md
+++ b/.opencode/command/spec_kit/resume.md
@@ -11,225 +11,139 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 > - `/spec_kit:resume specs/007-feature/ :auto` - Auto mode
 > - `/spec_kit:resume:auto specs/007-feature/` - Also valid (mode as suffix)
 
-# 🚨 MANDATORY PHASES - BLOCKING ENFORCEMENT
+# 🚨 SINGLE CONSOLIDATED PROMPT - ONE USER INTERACTION
 
-**These phases use CONSOLIDATED PROMPTS to minimize user round-trips. Each phase BLOCKS until complete. You CANNOT proceed to the workflow until ALL phases show ✅ PASSED or ⏭️ N/A.**
+**This workflow uses a SINGLE consolidated prompt to gather ALL required inputs in ONE user interaction.**
 
-**Round-trip optimization:** Resume uses 1-2 user interactions. Mode defaults to INTERACTIVE without asking.
-
----
-
-## 🔒 PHASE 1: INPUT & SESSION DETECTION
-
-**STATUS: ☐ BLOCKED**
-
-```
-EXECUTE THIS CHECK FIRST:
-
-1. CHECK for spec folder in $ARGUMENTS:
-
-├─ IF $ARGUMENTS contains a spec folder path:
-│   │
-│   ├─ Validate path exists: ls -d [spec_folder_input] 2>/dev/null
-│   │
-│   ├─ IF path exists:
-│   │   ├─ Store as: spec_path
-│   │   ├─ detection_method = "provided"
-│   │   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 3
-│   │
-│   └─ IF path NOT found:
-│       ├─ SHOW: "Spec folder not found: [path]"
-│       ├─ ASK: "Would you like to:"
-│       │   ┌────────────────────────────────────────────────────────────┐
-│       │   │ A) Try auto-detection (search for recent sessions)         │
-│       │   │ B) Provide a different path                                │
-│       │   │ C) Cancel                                                  │
-│       │   └────────────────────────────────────────────────────────────┘
-│       └─ WAIT for user response
-│
-└─ IF $ARGUMENTS is empty (auto-detect mode):
-    │
-    ├─ Find most recent memory file (Stateless - no .spec-active marker)
-    │   Glob("specs/**/memory/*.md") → Results sorted by modification time, take first
-    │
-    ├─ IF session found:
-    │   ├─ Store as: spec_path (extract from memory file path)
-    │   ├─ detection_method = "recent"
-    │   └─ SET STATUS: ✅ PASSED → Proceed to PHASE 3
-    │
-    └─ IF NO session found:
-        ├─ SHOW: "No active session detected"
-        ├─ ASK: "Would you like to:"
-        │   ┌────────────────────────────────────────────────────────────┐
-        │   │ A) List available spec folders and select one              │
-        │   │ B) Start new workflow with /spec_kit:complete               │
-        │   │ C) Cancel                                                  │
-        │   └────────────────────────────────────────────────────────────┘
-        └─ WAIT for user response
-
-**STOP HERE** - Wait for user to provide or confirm a valid spec folder path before continuing.
-
-⛔ HARD STOP: DO NOT proceed until a valid spec_path is confirmed
-```
-
-**Phase 1 Output:** `spec_path = ________________` | `detection_method = [recent/provided]`
-
----
-
-## 🔒 PHASE 2: CONTINUATION VALIDATION
-
-**STATUS: ☐ CONDITIONAL**
-
-```
-EXECUTE IF handoff pattern detected in $ARGUMENTS or recent user messages:
-
-1. CHECK for "CONTINUATION - Attempt" pattern:
-   ├─ IF detected:
-   │   ├─ Parse: Spec folder path, Last Completed, Next Action
-   │   │
-│   ├─ VALIDATE against most recent memory file:
-│   │   Glob("[spec_path]/memory/*.md") → Results sorted by modification time, take first
-   │   │   $ Read memory file → Extract "Project State Snapshot" section
-   │   │
-   │   ├─ COMPARE claimed progress vs actual progress:
-   │   │   - Claimed "Last Completed" matches memory "Last Action"?
-   │   │   - Claimed "Next Action" matches memory "Next Action"?
-   │   │
-   │   ├─ IF mismatch:
-   │   │   ├─ SHOW: "⚠️ State mismatch detected"
-   │   │   │   Claimed: Last=[X], Next=[Y]
-   │   │   │   Memory:  Last=[A], Next=[B]
-   │   │   ├─ ASK: "Which is correct?"
-   │   │   │   ┌──────────────────────────────────────────────────┐
-   │   │   │   │ A) Use handoff claims                            │
-   │   │   │   │ B) Use memory file state                          │
-   │   │   │   │ C) Investigate first                              │
-   │   │   │   └──────────────────────────────────────────────────┘
-   │   │   └─ WAIT for user response
-   │   │
-   │   └─ IF validated OR no memory files:
-   │       ├─ SHOW: "✅ Continuation validated"
-   │       └─ SET STATUS: ✅ PASSED
-   │
-   └─ IF NO handoff pattern:
-       └─ SET STATUS: ⏭️ N/A (not a continuation)
-
-⛔ SOFT STOP: Can proceed after acknowledgment
-```
+**Round-trip optimization:** Resume uses only 1 user interaction (all questions asked together). Mode defaults to INTERACTIVE unless :auto suffix is used.
 
 > **Gate 3 Note:** The resume command inherently satisfies Gate 3 because it REQUIRES a spec folder (either provided or detected). No separate Gate 3 question needed.
 
 ---
 
-## 🔒 PHASE 3: ARTIFACT VALIDATION & MODE SELECTION
+## 🔒 UNIFIED SETUP PHASE
 
 **STATUS: ☐ BLOCKED**
 
 ```
-EXECUTE AFTER PHASE 2 PASSES:
+EXECUTE THIS SINGLE CONSOLIDATED PROMPT:
 
-1. Check for required artifacts in spec_path:
-   $ ls -la [spec_path]/
-
-   Required (at least ONE must exist):
-   - spec.md
-   - plan.md OR tasks.md
-
-2. CHECK command invocation for mode suffix:
+1. CHECK for mode suffix in command invocation:
    ├─ ":auto" suffix detected → execution_mode = "AUTONOMOUS"
    ├─ ":confirm" suffix detected → execution_mode = "INTERACTIVE"
    └─ No suffix → execution_mode = "INTERACTIVE" (default for resume - safer)
 
-3. IF required artifacts missing:
-   ├─ SHOW: "Spec folder exists but missing required artifacts"
-   ├─ ASK: "Would you like to:"
-   │   ┌────────────────────────────────────────────────────────────┐
-   │   │ A) Run /spec_kit:plan to create planning artifacts         │
-   │   │ B) Select a different spec folder                          │
-   │   │ C) Continue anyway (limited resume)                        │
-   │   └────────────────────────────────────────────────────────────┘
-   └─ WAIT for user response
+2. CHECK for spec folder in $ARGUMENTS:
+   ├─ IF $ARGUMENTS has path → validate path exists
+   └─ IF $ARGUMENTS is empty → auto-detect from recent memory files
 
-4. IF artifacts exist:
-   ├─ Store artifact status
-   ├─ Store execution_mode
-   └─ SET STATUS: ✅ PASSED
+3. Auto-detect spec folder if needed:
+   - Glob("specs/**/memory/*.md") → Sort by modification time, take first
+   - IF found: spec_path = extracted path, detection_method = "recent"
+   - IF not found: detection_method = "none" (include Q0 in prompt)
 
-Note: Unlike other workflows, resume defaults to INTERACTIVE without asking,
-since it's a context-recovery operation where user review is beneficial.
+4. Check for "CONTINUATION - Attempt" handoff pattern in recent messages:
+   - IF detected: continuation_detected = TRUE, parse Last/Next values
+   - IF not detected: continuation_detected = FALSE
 
-**STOP HERE** - Wait for artifact validation or user selection before continuing.
+5. Validate artifacts in detected/provided spec folder:
+   - Check for: spec.md, plan.md, tasks.md
+   - Store: artifacts_valid = [yes/partial/no]
 
-⛔ HARD STOP: DO NOT proceed until artifacts are validated or user chooses option
+6. Check for memory files:
+   - $ ls [spec_path]/memory/*.md 2>/dev/null
+   - Store: memory_files_exist = [yes/no], memory_count = [N]
+
+7. ASK user with SINGLE CONSOLIDATED prompt (include only applicable questions):
+
+   ┌────────────────────────────────────────────────────────────────┐
+   │ **Before proceeding, please answer:**                          │
+   │                                                                │
+   │ **Q0. Spec Folder** (if not detected/provided):                │
+   │    No active session detected. Available spec folders:         │
+   │    [list folders if found]                                     │
+   │    A) List available spec folders and select one               │
+   │    B) Start new workflow with /spec_kit:complete                │
+   │    C) Cancel                                                   │
+   │                                                                │
+   │ **Q1. Confirm Detected Session** (if auto-detected):            │
+   │    Detected: [spec_path] (last activity: [date])               │
+   │    A) Yes, resume this session                                 │
+   │    B) No, select a different spec folder                       │
+   │    C) Cancel                                                   │
+   │                                                                │
+   │ **Q2. Continuation Validation** (if handoff pattern detected): │
+   │    Handoff claims: Last=[X], Next=[Y]                          │
+   │    Memory shows:   Last=[A], Next=[B]                          │
+   │    A) Use handoff claims                                       │
+   │    B) Use memory file state                                     │
+   │    C) Investigate first                                         │
+   │    [Skip if no mismatch OR no handoff pattern]                 │
+   │                                                                │
+   │ **Q3. Missing Artifacts** (if artifacts_valid != yes):         │
+   │    Spec folder exists but missing: [list]                      │
+   │    A) Run /spec_kit:plan to create planning artifacts          │
+   │    B) Select a different spec folder                           │
+   │    C) Continue anyway (limited resume)                         │
+   │                                                                │
+   │ **Q4. Memory Loading** (if memory files exist):                 │
+   │    Found [N] memory file(s) in [spec_path]/memory/              │
+   │    A) Load most recent memory                                  │
+   │    B) Load all memories (1-3 max)                              │
+   │    C) Skip memory loading                                      │
+   │                                                                │
+   │ Reply with answers, e.g.: "A, A" or "A, A, B"                  │
+   └────────────────────────────────────────────────────────────────┘
+
+8. WAIT for user response (DO NOT PROCEED)
+
+9. Parse response and store ALL results:
+   - spec_path = [from Q0/Q1 or auto-detected or $ARGUMENTS]
+   - detection_method = [provided/recent]
+   - execution_mode = [AUTONOMOUS/INTERACTIVE from suffix]
+   - continuation_choice = [from Q2, or N/A if no mismatch]
+   - artifacts_valid = [yes/partial/no]
+   - memory_choice = [A/B/C from Q4, or N/A if no memory files]
+
+10. Execute background operations based on choices:
+    - IF memory_choice == A: Load most recent memory file
+    - IF memory_choice == B: Load up to 3 recent memory files
+    - Calculate progress percentages from tasks.md/checklist.md
+
+11. SET STATUS: ✅ PASSED
+
+**STOP HERE** - Wait for user to answer ALL applicable questions before continuing.
+
+⛔ HARD STOP: DO NOT proceed until user explicitly answers
+⛔ NEVER assume spec folder without user confirmation when path was invalid
+⛔ NEVER split these questions into multiple prompts
 ```
 
-**Phase 3 Output:** `artifacts_valid = [yes/partial/no]` | `available_artifacts = [list]` | `execution_mode = ________________`
-
----
-
-## 🔒 PHASE 4: MEMORY LOADING
-
-**STATUS: ☐ CONDITIONAL**
-
-```
-EXECUTE AFTER PHASE 3 PASSES:
-
-1. CHECK for memory files in spec folder:
-   $ ls -la [spec_path]/memory/*.md 2>/dev/null
-
-2. IF memory files exist:
-   │
-   ├─ IF execution_mode = "AUTONOMOUS":
-   │   ├─ Auto-load most recent memory file
-   │   ├─ SHOW: "📚 Auto-loaded: [filename]"
-   │   └─ SET STATUS: ✅ PASSED
-   │
-   └─ IF execution_mode = "INTERACTIVE":
-       ├─ Count available memory files
-       ├─ SHOW: "Found [N] memory file(s) in [spec_path]/memory/"
-       ├─ ASK: "Memory Loading:"
-       │   ┌────────────────────────────────────────────────────────────┐
-       │   │ A) Load most recent memory                                 │
-       │   │ B) Load all memories (1-3 max)                             │
-       │   │ C) Select specific memory                                   │
-       │   │ D) Skip memory loading                                     │
-       │   └────────────────────────────────────────────────────────────┘
-       ├─ WAIT for user response
-       │
-       ├─ IF A: Load most recent memory file → Display summary
-       ├─ IF B: Load up to 3 most recent files → Display summaries
-       ├─ IF C: List all memory files → Wait for selection → Load
-       └─ IF D: Skip → Proceed without memory context
-       │
-       └─ SET STATUS: ✅ PASSED
-
-3. IF NO memory files exist:
-   ├─ SHOW: "ℹ️  No memory files found in [spec_path]/memory/"
-   └─ SET STATUS: ⏭️ N/A (no memories to load)
-
-Note: This implements Memory Context Loading from AGENTS.md Section 2.
-```
-
-**Phase 4 Output:** `memory_loaded = [yes/no/skipped]` | `memory_files = [list or none]`
+**Phase Output:**
+- `spec_path = ________________` | `detection_method = ________________`
+- `execution_mode = ________________`
+- `artifacts_valid = ________________`
+- `memory_loaded = ________________`
 
 ---
 
 ## ✅ PHASE STATUS VERIFICATION (BLOCKING)
 
-**Before continuing to the workflow, verify ALL phases:**
+**Before continuing to the workflow, verify ALL values are set:**
 
-| PHASE                       | REQUIRED STATUS   | YOUR STATUS | OUTPUT VALUE                       |
-| --------------------------- | ----------------- | ----------- | ---------------------------------- |
-| PHASE 1: INPUT & SESSION    | ✅ PASSED          | ______      | spec_path: ______ / method: ______ |
-| PHASE 2: CONTINUATION CHECK | ✅ PASSED or ⏭️ N/A | ______      | validated: ______ / source: ______ |
-| PHASE 3: ARTIFACTS & MODE   | ✅ PASSED          | ______      | artifacts: ______ / mode: ______   |
-| PHASE 4: MEMORY LOADING     | ✅ PASSED or ⏭️ N/A | ______      | memory: ______ / files: ______     |
+| FIELD            | REQUIRED      | YOUR VALUE | SOURCE                        |
+| ---------------- | ------------- | ---------- | ----------------------------- |
+| spec_path        | ✅ Yes         | ______     | Q0/Q1 or auto-detect or $ARGS |
+| detection_method | ✅ Yes         | ______     | Auto-determined               |
+| execution_mode   | ✅ Yes         | ______     | Suffix (defaults INTERACTIVE) |
+| artifacts_valid  | ✅ Yes         | ______     | Validation check              |
+| memory_loaded    | ○ Conditional | ______     | Q4 (if memory files exist)    |
 
 ```
 VERIFICATION CHECK:
-├─ ALL phases show ✅ PASSED or ⏭️ N/A?
+├─ ALL required fields have values?
 │   ├─ YES → Proceed to "# SpecKit Resume" section below
-│   └─ NO  → STOP and complete the blocked phase
+│   └─ NO  → Re-prompt for missing values only
 ```
 
 ---
@@ -237,21 +151,20 @@ VERIFICATION CHECK:
 ## ⚠️ VIOLATION SELF-DETECTION (BLOCKING)
 
 **YOU ARE IN VIOLATION IF YOU:**
-- Started reading the workflow section before all phases passed
-- Proceeded without validating artifacts exist (Phase 3)
+- Started reading the workflow section before all fields are set
+- Asked questions in MULTIPLE separate prompts instead of ONE consolidated prompt
+- Proceeded without validating artifacts exist
 - Assumed a spec folder without user confirmation when path was invalid
-- Skipped memory loading question when memory files exist (Phase 4)
-- Did not wait for user A/B/C/D response before loading memories in interactive mode
 - Did not display progress calculation
 - Claimed "resumed" without showing continuation options
 
 **VIOLATION RECOVERY PROTOCOL:**
 ```
 1. STOP immediately - do not continue current action
-2. STATE: "I violated PHASE [X] by [specific action]. Correcting now."
-3. RETURN to the violated phase
-4. COMPLETE the phase properly (ask user, wait for response)
-5. RESUME only after all phases pass verification
+2. STATE: "I asked questions separately instead of consolidated. Correcting now."
+3. PRESENT the single consolidated prompt with ALL applicable questions
+4. WAIT for user response
+5. RESUME only after all fields are set
 ```
 
 ---
@@ -420,12 +333,12 @@ The resume workflow uses semantic memory MCP tools directly for context loading.
 
 ### Checkpoint Tools
 
-| Tool                 | Purpose                              | Usage                                    |
-| -------------------- | ------------------------------------ | ---------------------------------------- |
-| `checkpoint_create`  | Create named checkpoint of state     | Snapshot memory state before major work  |
-| `checkpoint_list`    | List all available checkpoints       | Browse saved checkpoints with metadata   |
-| `checkpoint_restore` | Restore memory state from checkpoint | Rollback to a previous checkpoint state  |
-| `checkpoint_delete`  | Delete a checkpoint                  | Clean up old or unused checkpoints       |
+| Tool                 | Purpose                              | Usage                                   |
+| -------------------- | ------------------------------------ | --------------------------------------- |
+| `checkpoint_create`  | Create named checkpoint of state     | Snapshot memory state before major work |
+| `checkpoint_list`    | List all available checkpoints       | Browse saved checkpoints with metadata  |
+| `checkpoint_restore` | Restore memory state from checkpoint | Rollback to a previous checkpoint state |
+| `checkpoint_delete`  | Delete a checkpoint                  | Clean up old or unused checkpoints      |
 
 **Note:** There is no `memory_load` tool. Use `memory_search` with `includeContent: true` to load memory content directly in search results.
 
@@ -561,12 +474,12 @@ This command continues work from a handover:
 
 After resume completes, suggest relevant next steps based on progress:
 
-| Condition | Suggested Command | Reason |
-|-----------|-------------------|--------|
-| Planning incomplete | `/spec_kit:plan [feature-description]` | Complete planning phase |
-| Ready to implement | `/spec_kit:implement [spec-folder-path]` | Continue implementation |
-| Implementation in progress | Continue from last task | Resume where you left off |
-| Found issues | `/spec_kit:debug [spec-folder-path]` | Debug problems |
-| Session ending again | `/spec_kit:handover [spec-folder-path]` | Save progress for later |
+| Condition                  | Suggested Command                        | Reason                    |
+| -------------------------- | ---------------------------------------- | ------------------------- |
+| Planning incomplete        | `/spec_kit:plan [feature-description]`   | Complete planning phase   |
+| Ready to implement         | `/spec_kit:implement [spec-folder-path]` | Continue implementation   |
+| Implementation in progress | Continue from last task                  | Resume where you left off |
+| Found issues               | `/spec_kit:debug [spec-folder-path]`     | Debug problems            |
+| Session ending again       | `/spec_kit:handover [spec-folder-path]`  | Save progress for later   |
 
 **ALWAYS** end with: "What would you like to do next?"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ Public Release: https://github.com/MichelKerkmeester/opencode-dev-environment
 
 ---
 
+## [**1.0.7.2**] - 2026-01-23
+
+Removes **outdated model version references** from all SpecKit commands and YAML configurations. Model selection now uses generic provider names (Claude, Gemini, Codex) instead of specific versions like GPT-4/o1 or Pro/Ultra.
+
+---
+
+### Changed
+
+**User-Facing Model Selection (debug.md)**
+1. **Q2 AI Model options** simplified:
+   - `B) Gemini - Google models (Pro/Ultra)` → `B) Gemini - Google`
+   - `C) Codex - OpenAI models (GPT-4/o1)` → `C) Codex - OpenAI`
+
+**Dispatch Mode Descriptions (All YAML Configs)**
+2. **Mode descriptions** made model-agnostic:
+   - `1 Opus orchestrator + 2 Sonnet parallel workers` → `1 orchestrator + 2 parallel workers`
+   - `1 Opus orchestrator + 3 Sonnet parallel workers` → `1 orchestrator + 3 parallel workers`
+
+**Internal Documentation (Command .md Files)**
+3. **Agent routing tables** simplified — removed Model column, added note about automatic selection
+4. **Parallel dispatch notes** — removed specific model tier references
+
+---
+
+### Files Changed
+
+**Commands (4)**
+- `debug.md` · `complete.md` · `plan.md` · `handover.md`
+
+**YAML Configs (10)**
+- `spec_kit_debug_auto.yaml` · `spec_kit_debug_confirm.yaml`
+- `spec_kit_complete_auto.yaml` · `spec_kit_complete_confirm.yaml`
+- `spec_kit_plan_auto.yaml` · `spec_kit_plan_confirm.yaml`
+- `spec_kit_implement_auto.yaml` · `spec_kit_implement_confirm.yaml`
+- `spec_kit_research_auto.yaml` · `spec_kit_research_confirm.yaml`
+
+---
+
+### Upgrade
+
+No action required. Pull latest to get model-agnostic naming.
+
+**Full Changelog**: [v1.0.7.1...v1.0.7.2](https://github.com/MichelKerkmeester/opencode-dev-environment/compare/v1.0.7.1...v1.0.7.2)
+
+---
+
 ## [**1.0.7.1**] - 2026-01-23
 
 Adds **user-selectable multi-agent dispatch** to all 5 spec_kit work-execution commands, enabling 1 Opus orchestrator + 2-3 Sonnet parallel workers. Includes Coordinator/Worker mode instructions in agent files and `multi_agent_config` sections in **12 YAML configs**.


### PR DESCRIPTION
Removes **outdated model version references** from all SpecKit commands and YAML configurations. Model selection now uses generic provider names (Claude, Gemini, Codex) instead of specific versions like GPT-4/o1 or Pro/Ultra.

## Highlights

### 🔧 Model-Agnostic Naming
- **User-facing model selection**: Simplified options (removed Pro/Ultra, GPT-4/o1)
- **Dispatch mode descriptions**: `1 Opus orchestrator + 2 Sonnet workers` → `1 orchestrator + 2 workers`
- **Internal documentation**: Removed Model column from routing tables, added automatic selection note

## Files Changed

**Commands (4)**
- `debug.md` · `complete.md` · `plan.md` · `handover.md`

**YAML Configs (10)**
- `spec_kit_debug_auto.yaml` · `spec_kit_debug_confirm.yaml`
- `spec_kit_complete_auto.yaml` · `spec_kit_complete_confirm.yaml`
- `spec_kit_plan_auto.yaml` · `spec_kit_plan_confirm.yaml`
- `spec_kit_implement_auto.yaml` · `spec_kit_implement_confirm.yaml`
- `spec_kit_research_auto.yaml` · `spec_kit_research_confirm.yaml`

## Upgrade

No action required. Pull latest to get model-agnostic naming.