### PR TITLE
fix: apply AGENTS.md audit fixes (B2, B3, skills) + spec 118

### DIFF
--- a/.opencode/scripts/skill_advisor.py
+++ b/.opencode/scripts/skill_advisor.py
@@ -251,13 +251,13 @@ INTENT_BOOSTERS = {
     "template": ("workflows-documentation", 0.4),
     
     # ─────────────────────────────────────────────────────────────────
-    # WORKFLOWS-CODE: Implementation and verification (frontend/Webflow)
+    # WORKFLOWS-CODE--WEB-DEV: Implementation and verification (frontend/Webflow)
     # ─────────────────────────────────────────────────────────────────
-    "bug": ("workflows-code", 0.5),
-    "error": ("workflows-code", 0.4),
-    "implement": ("workflows-code", 0.6),
-    "refactor": ("workflows-code", 0.5),
-    "verification": ("workflows-code", 0.5),
+    "bug": ("workflows-code--web-dev", 0.5),
+    "error": ("workflows-code--web-dev", 0.4),
+    "implement": ("workflows-code--web-dev", 0.6),
+    "refactor": ("workflows-code--web-dev", 0.5),
+    "verification": ("workflows-code--web-dev", 0.5),
 
     # ─────────────────────────────────────────────────────────────────
     # WORKFLOWS-CODE--OPENCODE: OpenCode system code standards
@@ -300,20 +300,20 @@ INTENT_BOOSTERS = {
 MULTI_SKILL_BOOSTERS = {
     "api": [("mcp-code-mode", 0.3)],
     "changes": [("workflows-git", 0.4), ("system-spec-kit", 0.2)],
-    "code": [("workflows-code", 0.2), ("workflows-code--opencode", 0.1)],
+    "code": [("workflows-code--web-dev", 0.2), ("workflows-code--full-stack", 0.2), ("workflows-code--opencode", 0.1)],
     "context": [("system-spec-kit", 0.4)],
-    "fix": [("workflows-code", 0.3), ("workflows-git", 0.1)],
+    "fix": [("workflows-code--web-dev", 0.3), ("workflows-code--full-stack", 0.3), ("workflows-git", 0.1)],
     "mcp": [("mcp-code-mode", 0.3), ("workflows-code--opencode", 0.4)],
-    "plan": [("system-spec-kit", 0.3), ("workflows-code", 0.2)],
+    "plan": [("system-spec-kit", 0.3), ("workflows-code--web-dev", 0.2), ("workflows-code--full-stack", 0.2)],
     "save": [("system-spec-kit", 0.4), ("workflows-git", 0.2)],
     "script": [("workflows-code--opencode", 0.4)],
     "server": [("workflows-code--opencode", 0.3), ("mcp-code-mode", 0.2)],
     "session": [("system-spec-kit", 0.5)],
-    "standards": [("workflows-code--opencode", 0.4), ("workflows-code", 0.2)],
-    "style": [("workflows-code--opencode", 0.3), ("workflows-code", 0.2)],
+    "standards": [("workflows-code--opencode", 0.4), ("workflows-code--web-dev", 0.2), ("workflows-code--full-stack", 0.2)],
+    "style": [("workflows-code--opencode", 0.3), ("workflows-code--web-dev", 0.2), ("workflows-code--full-stack", 0.2)],
     "task": [("system-spec-kit", 0.3)],
-    "test": [("workflows-code", 0.3), ("workflows-chrome-devtools", 0.2)],
-    "update": [("mcp-code-mode", 0.3), ("workflows-git", 0.2), ("workflows-code", 0.2)],
+    "test": [("workflows-code--web-dev", 0.3), ("workflows-code--full-stack", 0.3), ("workflows-chrome-devtools", 0.2)],
+    "update": [("mcp-code-mode", 0.3), ("workflows-git", 0.2), ("workflows-code--web-dev", 0.2), ("workflows-code--full-stack", 0.2)],
 }
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,6 +554,20 @@ Task Received → Gate 2: Run skill_advisor.py
 4. Follow skill instructions to completion
 5. Do NOT re-invoke a skill already in context
 
+### Available Skills
+
+| Skill                          | Description                                                                                       | Path                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `system-spec-kit`              | Spec folder documentation, template architecture, validation, and Spec Kit Memory                 | `.opencode/skill/system-spec-kit/`                 |
+| `workflows-code--web-dev`      | Single-stack web code orchestrator (Webflow, vanilla JS) with 3-phase lifecycle                   | `.opencode/skill/workflows-code--web-dev/`         |
+| `workflows-code--full-stack`   | Multi-stack code orchestrator (Go, Node.js, React, React Native, Swift) with auto-detection       | `.opencode/skill/workflows-code--full-stack/`      |
+| `workflows-code--opencode`     | Multi-language code standards for OpenCode system code (JS, TS, Python, Shell, JSON/JSONC)        | `.opencode/skill/workflows-code--opencode/`        |
+| `workflows-documentation`      | Markdown and OpenCode component specialist (document quality, content optimization, install guides)| `.opencode/skill/workflows-documentation/`         |
+| `workflows-git`                | Git workflow orchestrator (workspace setup, clean commits, work completion)                        | `.opencode/skill/workflows-git/`                   |
+| `workflows-chrome-devtools`    | Chrome DevTools automation via CLI (bdg) and MCP with intelligent routing                         | `.opencode/skill/workflows-chrome-devtools/`       |
+| `mcp-code-mode`                | MCP orchestration via TypeScript execution for external tools (Webflow, Figma, ClickUp, etc.)     | `.opencode/skill/mcp-code-mode/`                   |
+| `mcp-figma`                    | Figma design file access via MCP (18 tools for file retrieval, export, components, styles)        | `.opencode/skill/mcp-figma/`                       |
+
 ### Primary Skill: workflows-code
 
 For ALL frontend code implementation, `workflows-code` is the primary orchestrator skill.
@@ -573,7 +587,7 @@ Skills are located in `.opencode/skill/`.
 When creating or editing skills:
 - Create or edit skills based on the workflow logic defined in `.opencode/agent/write.md`
 - Validate skill structure matches template in `workflows-documentation/references/skill_creation.md`
-- Use the templates in `workflows-documentation/assets/` (`skill_md_template.md`, `skill_reference_template.md`, `skill_asset_template.md`)
+- Use the templates in `workflows-documentation/assets/opencode/` (`skill_md_template.md`, `skill_reference_template.md`, `skill_asset_template.md`)
 - Ensure all bundled resources are referenced with relative paths
 - Test skill invocation before committing
 


### PR DESCRIPTION
## Summary
- Fix 12 phantom `workflows-code` references in `skill_advisor.py` (B2) — split to correct `--web-dev` and `--full-stack` variants
- Fix template asset path missing `opencode/` subdirectory in AGENTS.md (B3)
- Add 4 missing skills to AGENTS.md §9: `mcp-code-mode`, `mcp-figma`, `workflows-chrome-devtools`, `workflows-code--opencode`
- Create spec folder `specs/118-agents-md-fixes/` documenting all audit fixes across 3 repos