### PR TITLE
feat(create-benchmark): complete six-family benchmark-authoring centralization (016/002)

### DIFF
--- a/.opencode/skills/sk-doc/create-benchmark/SKILL.md
+++ b/.opencode/skills/sk-doc/create-benchmark/SKILL.md
@@ -2,7 +2,7 @@
 name: create-benchmark
 description: Author benchmark artifacts across families - MCP-promotion benchmark_report.md plus SOURCE.md; deep-loop behavior_benchmark packages; Lane C skill-benchmark benchmark/ storage tree plus README index; and Lane B model-benchmark fixtures plus profiles. Scoring contracts and report renderers stay lane-owned and cross-linked, not templated here.
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
-version: 1.2.0.0
+version: 1.3.0.0
 ---
 
 <!-- Keywords: create-benchmark, benchmark_report.md, SOURCE.md, mcp_server benchmarks, benchmark promotion, skill-local benchmark, MCP bake-off, benchmark folder, behavior benchmark, behavior_benchmark.md, scenario contract, DAB scenario, behavior-benchmark framework, claude-baseline, skill-benchmark, benchmark/README.md, run-label folder, skill-benchmark-report, Lane C benchmark, model-benchmark, benchmark fixture, benchmark profile, code-task oracle fixture, reviewer-prompt fixture, Lane B fixture -->
@@ -16,7 +16,7 @@ version: 1.2.0.0
 - **Skill-benchmark (Lane C)** — author a hub's `benchmark/` storage tree and its `benchmark/README.md` run-label index; the per-run `skill-benchmark-report.md` is a renderer-owned render this packet never authors (section 10).
 - **Model-benchmark (Lane B)** — author the Lane B input fixtures (code-task oracle, pattern/capability, reviewer-prompt) and the run profiles; the evaluator, scorers, and reviewer-verdict contract stay lane-local (section 11).
 
-Two further families — Lane A agent-improvement and Lane D non-dev AI-system improvement — appear only for disambiguation; their code-owned artifacts stay in-lane and are not templated here.
+Two further families — Lane A agent-improvement and Lane D non-dev AI-system improvement — now carry an authoring guide here (section 12); their code-owned artifacts stay in-lane.
 
 The skill-local surface is the look-here-first entry point, not the archive; the full audit trail stays in the owning spec packet or lane.
 
@@ -33,7 +33,7 @@ Use this packet when a completed benchmark, or a benchmark's input artifacts, ne
 - **Skill-benchmark** (section 10) — author or update a hub's `benchmark/README.md` run-label index, or establish the `benchmark/` storage convention (sibling run-label folders, frozen `baseline/` anchor) for a Lane C tree.
 - **Model-benchmark** (section 11) — author a Lane B input fixture (code-task oracle, pattern/capability, or reviewer-prompt) or a run profile that selects fixtures, models, frameworks, scoring, and the gate.
 
-Keyword triggers: `benchmark_report.md`, `SOURCE.md`, `mcp_server/benchmarks`, `MCP bake-off`; `behavior benchmark`, `behavior_benchmark.md`, `scenario contract`, `claude-baseline`; `skill-benchmark`, `benchmark/README.md`, `run-label folder`, `skill-benchmark-report`; `model-benchmark`, `benchmark fixture`, `benchmark profile`, `reviewer-prompt fixture`.
+Keyword triggers: `benchmark_report.md`, `SOURCE.md`, `mcp_server/benchmarks`, `MCP bake-off`; `behavior benchmark`, `behavior_benchmark.md`, `scenario contract`, `claude-baseline`; `skill-benchmark`, `benchmark/README.md`, `run-label folder`, `benchmark package`; `model-benchmark`, `benchmark fixture`, `benchmark profile`, `reviewer-prompt fixture`.
 
 ### Adoption Gate (MCP promotion)
 
@@ -92,14 +92,14 @@ Route to the right family before authoring; the families are distinct and must n
 | Behavior | Executor-model behavior at a deep-loop mode's invocation surface | `<mode>/behavior_benchmark/` | Index, scenario, and baseline templates + the authoring guide | Measurement contract → `system-deep-loop/shared/behavior-benchmark/framework.md` | §9 |
 | Skill-benchmark (Lane C) | Whether a skill is well-routed, discoverable, efficient, and useful | `<skill>/benchmark/<run-label>/` | The storage guide + the hub `benchmark/README.md` index template | `skill-benchmark-report.md` render → `build-report.cjs`; D1-D5 scoring → deep-improvement `scoring_contract.md` | §10 |
 | Model-benchmark (Lane B) | What a model or prompt framework produces against a held-out oracle | `system-deep-loop/deep-improvement/assets/model_benchmark/` | Code-task, pattern/capability, and reviewer fixture templates + the profile template + the fixture guide | Evaluator / scorer / reviewer-verdict contract → deep-improvement lane | §11 |
-| Agent-improvement (Lane A) | An agent's quality across five dimensions | deep-improvement lane (in-lane) | **Nothing — NON-GOAL** | Code-owned: authored and run in-lane by `/deep:agent-improvement` | — |
-| AI-system improvement (Lane D, non-dev) | A non-dev AI-system packaging's technique docs | deep-improvement lane (in-lane) | **Nothing — NON-GOAL** | Code-owned: authored and run in-lane by `/deep:ai-system-improvement` | — |
+| Agent-improvement (Lane A) | An agent's quality across five dimensions | deep-improvement lane (in-lane) | Authoring guide ([guide](references/agent_improvement/agent_improvement_authoring_guide.md)) | Code-owned rubric/config; run by `/deep:agent-improvement` | §12 |
+| AI-system improvement (Lane D, non-dev) | A non-dev AI-system packaging's technique docs | deep-improvement lane (in-lane) | Authoring guide ([guide](references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md)) | Code-owned schema/templates; run by `/deep:ai-system-improvement` | §12 |
 
 ### Routing Decision
 
 Pick the family by what the task authors: shipped MCP-stack numbers into a skill's code tree → MCP promotion (§3-8); executor-model behavior at a deep-loop mode's surface → behavior (§9); where a Lane C run's report pair is stored, or a hub `benchmark/README.md` index → skill-benchmark (§10); a Lane B input fixture or run profile → model-benchmark (§11). Two hard stops: to hand-write a `skill-benchmark-report.md`, don't — it is renderer-owned; to change how any benchmark is *scored*, don't — the scoring contracts are lane-local.
 
-**Non-goals.** Lane A (agent-improvement) and Lane D (non-dev AI-system improvement) appear in the table only for router disambiguation. Their fixtures, evaluators, and reports are authored and run entirely in-lane; `create-benchmark` ships no template, guide, or index for either — route those to `/deep:agent-improvement` or `/deep:ai-system-improvement`.
+**Lane A and Lane D.** create-benchmark hosts an authoring guide for each (section 12); their fixtures, evaluators, configs, schemas, and templates stay code-owned in-lane. Route a run to `/deep:agent-improvement` or `/deep:ai-system-improvement`.
 
 ### Family Boundary
 
@@ -136,9 +136,9 @@ Required and optional files:
 
 `SOURCE.md` is a wayfinding file, not a duplicate audit trail. It contains the spec packet path, why to read it, question-to-file mapping, evidence map, follow-on packet notes, rename or renumber notes, and last-updated date.
 
-Use `assets/shared/benchmark_report_template.md` for `benchmark_report.md` and `assets/shared/source_template.md` for `SOURCE.md`.
+Use `assets/_shared/benchmark_report_template.md` for `benchmark_report.md` and `assets/_shared/source_template.md` for `SOURCE.md`.
 
-Reference `references/shared/README.md` for deep overflow: it routes to the case studies, the report worked example, and common pitfalls.
+Reference `references/_shared/README.md` for deep overflow: it routes to the case studies, the report worked example, and common pitfalls.
 
 ---
 
@@ -505,10 +505,12 @@ Each template's fenced json block is the only thing copied into the shipped `.js
 
 **Within this packet** — family guides and the overflow route-map; the fillable templates are mapped in each family section above:
 
-- [`references/shared/README.md`](references/shared/README.md) — overflow route-map (case studies, worked example, pitfalls).
+- [`references/_shared/README.md`](references/_shared/README.md) — overflow route-map (case studies, worked example, pitfalls).
 - [`references/behavior_benchmark/behavior_benchmark_guide.md`](references/behavior_benchmark/behavior_benchmark_guide.md) — behavior package authoring path (§9).
 - [`references/skill_benchmark/skill_benchmark_storage_guide.md`](references/skill_benchmark/skill_benchmark_storage_guide.md) — skill-benchmark storage convention and renderer boundary (§10).
 - [`references/model_benchmark/model_benchmark_fixture_guide.md`](references/model_benchmark/model_benchmark_fixture_guide.md) — model-benchmark fixture taxonomy, profile shape, lane boundary (§11).
+- [`agent_improvement_authoring_guide.md`](references/agent_improvement/agent_improvement_authoring_guide.md) — Lane A input authoring (§2).
+- [`non_dev_ai_system_authoring_guide.md`](references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md) — Lane D input authoring (§2).
 
 **Lane-owned contracts** — cross-link, never restate:
 

--- a/.opencode/skills/sk-doc/create-benchmark/changelog/v1.3.0.0.md
+++ b/.opencode/skills/sk-doc/create-benchmark/changelog/v1.3.0.0.md
@@ -1,0 +1,22 @@
+---
+title: "create-benchmark v1.3.0.0 changelog"
+version: 1.3.0.0
+---
+
+# v1.3.0.0 — Lane A and Lane D authoring guides; six-family coverage completed
+
+`create-benchmark` now hosts an authoring guide for every benchmark family. The previous release authored four families (MCP promotion, behavior, skill-benchmark, model-benchmark) and named Lane A (agent-improvement) and Lane D (non-dev AI-system improvement) as code-owned non-goals. This release adds authoring guides for those two families, so the packet is the single home for benchmark document-creation guidance across all six — while every run/scoring contract, schema, and code-coupled template stays lane-owned in `system-deep-loop/deep-improvement` and is cross-linked, never relocated.
+
+## What Added
+
+- **`references/agent_improvement/agent_improvement_authoring_guide.md`** — Lane A (agent-improvement) authoring guide. Covers the doc-only inputs an author fills before a run — the improvement charter and strategy scaffolds, the target-onboarding classification, the candidate proposal format, and the profiling / integration-scanning setup. The five-dimension `score_dimensions.md` rubric, the `evaluator_contract.md`, the `promotion_gate_contract.md`, and the code-coupled `improvement_config.json` stay lane-local and are cross-linked, never restated.
+- **`references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md`** — Lane D (non-dev AI-system) authoring guide. Covers the doc-only inputs — the packaging config filled from `packaging_config.example.json`, the fixture and gold-set choices, the grader-calibration selections, and the operator run setup. The `packaging_config.schema.json`, the nine `templates/*.template` scaffolds (rendered by `init_packaging.py` by exact filename), and `loop_contract.md` are code-owned in-lane and are cross-linked, explicitly never relocated.
+
+## What Changed
+
+- **SKILL.md §2 Smart Routing** — the six-family table now names an authoring guide for Lane A and Lane D in the OWNS column (previously "Nothing — NON-GOAL"), with their rubrics, configs, schemas, and templates kept as in-lane code-owned routes. The §1 framing and the Lane A/Lane D routing paragraph were reworded accordingly, and §12 REFERENCES gained the two new guides. Edits were kept word-neutral to hold the SKILL under its word cap.
+- **Bidirectional links completed** — added the previously-missing lane-to-hub authoring back-pointers: `deep-alignment/behavior_benchmark/behavior_benchmark.md` (its first reference to create-benchmark), the Lane A `assets/agent_improvement/README.md`, and the Lane D `references/non_dev_ai_system/operator_guide.md`. The create-benchmark-to-lane direction (guides linking the lane contracts) ships with the two new guides.
+
+## Boundary Held
+
+No measurement contract, scoring rubric, schema, scorer, runner, or code-coupled template was moved into create-benchmark. "Single home" means single home for authoring guidance; run and scoring ownership stays with the lanes that execute (see the packet decision record, ADR-002).

--- a/.opencode/skills/sk-doc/create-benchmark/references/agent_improvement/agent_improvement_authoring_guide.md
+++ b/.opencode/skills/sk-doc/create-benchmark/references/agent_improvement/agent_improvement_authoring_guide.md
@@ -1,0 +1,241 @@
+---
+title: Agent-Improvement Authoring Guide
+description: End-to-end guide for authoring the doc-only inputs a Lane A (agent-improvement) run consumes - the improvement charter and strategy scaffolds, the target-onboarding classification, the candidate proposal format, and the profiling/integration-scanning setup; where each lives in deep-improvement and what stays lane-local and code-owned.
+trigger_phrases:
+  - "agent improvement authoring guide"
+  - "how to author lane A inputs"
+  - "improvement charter and strategy scaffold"
+  - "candidate proposal doc authoring"
+  - "agent-improvement setup docs"
+importance_tier: normal
+contextType: reference
+version: 1.0.0.0
+---
+
+# Agent-Improvement Authoring Guide
+
+Authoring depth for the Lane A (agent-improvement) inputs. This guide covers what you
+WRITE before a run: the setup scaffolds an author fills, the candidate format a
+proposal follows, and the profiling/integration-scanning setup a target needs. It does
+NOT restate how those inputs are scored or promoted — the five-dimension rubric, the
+evaluator contract, the promotion-gate contract, and the code-coupled run config are
+the deep-improvement lane's, and they stay lane-local. Cross-links throughout point at
+those normative contracts; where this guide and a contract diverge, the contract
+prevails.
+
+---
+
+## 1. OVERVIEW: WHAT LANE A AUTHORING COVERS
+
+Lane A improves a **bounded agent `.md` file** without immediately mutating the source
+of truth. It is run by [`/deep:agent-improvement`](../../../../system-deep-loop/deep-improvement/SKILL.md)
+and is evaluator-first: it generates packet-local candidates, scores them with dynamic
+5-dimension scoring, and promotes only behind guarded gates plus explicit operator
+approval. The loop, its lifecycle, and its scoring are code and contracts that ship
+with the lane. What an *author* provides is a small set of **doc-only setup inputs**
+plus a filled copy of the code-coupled run config.
+
+Everything here is authoring input; nothing an author fills executes on its own. The
+lane's scripts (`generate-profile.cjs`, `scan-integration.cjs`, `score-candidate.cjs`,
+`run-benchmark.cjs`, `promote-candidate.cjs`) read the inputs, score candidates, and
+write evidence into the packet-local `improvement/` runtime area.
+
+### Lane boundary — what stays lane-local
+
+| This guide covers (authoring inputs) | Stays lane-local in deep-improvement (cross-link) |
+| --- | --- |
+| Charter + strategy scaffolds, and which fields an author fills | The five-dimension rubric, weights, and weighted-score threshold |
+| Target-onboarding preconditions and the canonical/derived/candidate-only classes | The evaluator input/output contract and reject-vs-infra-failure rule |
+| The candidate file shape: frontmatter fields and the mutation-type vocabulary | The promotion-gate contract, per-dimension gates, and legal-stop bundles |
+| Which config fields an author fills in a copy | The canonical `improvement_config.json` template and its field reference |
+
+The right-hand column is normative and code-backed. Author *to* it; do not re-document
+it here.
+
+---
+
+## 2. WHAT YOU AUTHOR: THE LANE A SETUP DOCS
+
+All Lane A data lives under the deep-improvement mode-packet in
+[`assets/agent_improvement/`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/README.md)
+(scaffolds and config) and
+[`references/agent_improvement/`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/target_onboarding.md)
+(the format and setup references). A run copies the scaffolds into its packet-local
+`improvement/` runtime area and edits the copies; the source templates are edited by
+maintainers, not by a run.
+
+| Input | Where it lives (link) | What the author does |
+| --- | --- | --- |
+| Charter scaffold | [`improvement_charter.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_charter.md) | Adopt verbatim as the fixed policy layer — mission, dynamic-target rule, proposal-only policy, keep/discard rule, and the audit obligations. It is **immutable** for the run; the mutator must never rewrite it. |
+| Strategy scaffold | [`improvement_strategy.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_strategy.md) | Fill the operator-owned fields (Target, Goal, Constraints, Current Hypothesis, Candidate Focus, Benchmark Focus, Integration Focus) before the run; leave the `MACHINE-OWNED` block for the reducer. |
+| Run config (copy) | [`improvement_config.json`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config.json) | Fill only `target`, `specFolder`, and `lineage.sessionId` in a packet-local copy; leave scoring, stop-rule, dispatch-cap, and file-protection sections at their template values. See §3. |
+| Target manifest | [`target_manifest.jsonc`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/target_manifest.jsonc) | Optionally add a classification entry or extend the `fixed`/`forbidden` protections; the `targets` array is intentionally empty under dynamic-only profiling. |
+| Candidate file | (per format) [`candidate_proposal_format.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/candidate_proposal_format.md) | Write each candidate as a complete agent `.md` under `{spec_folder}/improvement/candidates/` that differs from the target only in the one mutation being tested. |
+
+### 2.1 The candidate file, at a glance
+
+A candidate is a full agent file plus proposal frontmatter. The required proposal
+fields are `candidate_id`, `session_id`, `iteration`, `mutation_type`,
+`target_dimension`, `parent_candidate`, and `created_at`; the standard agent fields
+(`name`, `description`, `triggers`, `version`) are inherited from the target. The
+`mutation_type` is drawn from a fixed vocabulary — `rule-addition`,
+`rule-modification`, `workflow-addition`, `workflow-modification`, `description-update`,
+`verification-addition`, `integration-fix` — each mapped to the dimension it targets.
+The full field rules, mutation-signature dedup, and lineage-graph shape are the
+authority in
+[`candidate_proposal_format.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/candidate_proposal_format.md);
+this is the shape at a glance.
+
+### 2.2 Onboarding a new target
+
+Before a target can be evaluated it must be classifiable and benchmarkable. The
+preconditions (structured output contract, deterministic or policy-stable benchmarking,
+a clear class, no mirror-sync dependency) and the three classes — `canonical`,
+`derived`, `candidate-only` — are documented in
+[`target_onboarding.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/target_onboarding.md).
+Author against it; do not invent new target classes here.
+
+### 2.3 The profiling / integration-scanning setup
+
+Two lane references describe the surfaces a target profile is built from and how the
+integration dimension is measured. The full inventory of scanned surfaces (canonical,
+runtime mirrors, commands, YAML workflows, skills, global docs, skill advisor) and the
+mirror-sync signal-matching rule live in
+[`integration_scanning.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/integration_scanning.md).
+The append-only profile-selection rationale log (`profile-selection.log`, written under
+the packet-local `improvement/` state directory) is documented in
+[`profiling_audit_log.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/profiling_audit_log.md).
+Profiles are generated dynamically per target; no static profiles ship.
+
+---
+
+## 3. WHAT STAYS LANE-LOCAL / CODE-OWNED
+
+These are normative and code-backed. Name them for wayfinding, link them, and **never
+restate** them here; where this guide and one of them diverge, the contract prevails.
+
+| Lane authority (link) | What it owns — do not restate |
+| --- | --- |
+| [`score_dimensions.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/score_dimensions.md) | The five dimensions (structural integrity, rule coherence, integration consistency, output quality, system fitness), their weights, and the weighted-score threshold. |
+| [`evaluator_contract.md`](../../../../system-deep-loop/deep-improvement/references/model_benchmark/evaluator_contract.md) | Scorer and benchmark-runner input/output contract, the rubric, and the reject-vs-`infra_failure` distinction. |
+| [`promotion_gate_contract.md`](../../../../system-deep-loop/deep-improvement/references/shared/promotion_gate_contract.md) | The five promotion gates, per-dimension minimums, the accept/ship phases, and rollback. |
+| [`improvement_charter.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_charter.md) | The journal-emission protocol, the stop-reason enum, and the legal-stop gate bundles (contract / behavior / integration / evidence / improvement). |
+
+### The code-coupled run config
+
+`improvement_config.json` is **code-coupled**: the lane's scripts read it at runtime —
+for example `scripts/shared/check-dispatch-cap.cjs` enforces the `dispatchCaps` ceilings
+from it before every candidate dispatch, score, and benchmark run, and the manifest
+names `generate-profile.cjs` and `scan-integration.cjs` as its consumers. An author
+fills a *copy* (only `target`, `specFolder`, `lineage.sessionId` — see §2), but the
+canonical template and its field-by-field meaning stay in the lane. Do not restate the
+config schema here; the field reference is
+[`improvement_config_reference.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config_reference.md).
+Never hand-move the config template out of the lane into this packet.
+
+---
+
+## 4. AUTHORING WORKFLOW
+
+Complete these steps in order. This workflow produces inputs; it never runs the loop.
+
+1. **Confirm the target and classify it.** Pick the bounded agent `.md` and classify it
+   (`canonical` / `derived` / `candidate-only`) per
+   [`target_onboarding.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/target_onboarding.md);
+   confirm the preconditions hold before going further.
+2. **Copy and fill the scaffolds.** Adopt
+   [`improvement_charter.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_charter.md)
+   verbatim, then fill the operator-owned fields of
+   [`improvement_strategy.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_strategy.md).
+3. **Fill the run-config copy.** Set `target`, `specFolder`, and `lineage.sessionId` in a
+   packet-local copy of
+   [`improvement_config.json`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config.json);
+   leave everything else at template values (see
+   [`improvement_config_reference.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config_reference.md)).
+4. **Set up profiling and integration surfaces.** Confirm the target's scanned surfaces
+   against
+   [`integration_scanning.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/integration_scanning.md)
+   so the integration dimension has real signal to measure.
+5. **Author the first candidate.** Write it to the format in
+   [`candidate_proposal_format.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/candidate_proposal_format.md):
+   one bounded mutation, correct `mutation_type` / `target_dimension`, packet-local under
+   `candidates/`.
+6. **Hand off to the lane to run.** The lane scores, benchmarks, and gates the candidate
+   ([`loop_protocol.md`](../../../../system-deep-loop/deep-improvement/references/shared/loop_protocol.md)); authoring stops before scoring, promotion, or mirror sync.
+
+---
+
+## 5. ALWAYS / NEVER
+
+### ALWAYS
+- **ALWAYS** generate candidates evaluator-first: propose one bounded mutation, then let
+  the lane score it — never edit the canonical target during proposal-only mode.
+- **ALWAYS** write candidates and filled scaffolds under the packet-local
+  `{spec_folder}/improvement/` area, leaving the lane's source templates untouched.
+- **ALWAYS** fill only the operator-owned fields; leave `MACHINE-OWNED` strategy blocks
+  and the scoring/stop-rule config sections for the reducer and the lane.
+
+### NEVER
+- **NEVER** restate the five-dimension rubric, the promotion gates, or the legal-stop
+  gate bundles in this guide — name and link them; the contract prevails.
+- **NEVER** hand-move the code-coupled `improvement_config.json` template (or its field
+  reference) out of the lane into this packet.
+- **NEVER** treat runtime-mirror sync as benchmark evidence; mirror drift is downstream
+  packaging work per [`mirror_drift_policy.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/mirror_drift_policy.md).
+
+---
+
+## 6. SUCCESS CRITERIA
+
+- The charter is adopted verbatim and the strategy's operator-owned fields are filled
+  before the run; the `MACHINE-OWNED` block is untouched.
+- The run-config copy carries a real `target`, `specFolder`, and `lineage.sessionId`,
+  and no other section was hand-edited away from the template.
+- Each candidate is a complete agent file with valid proposal frontmatter, a single
+  bounded mutation, and a `mutation_type` from the documented vocabulary.
+- No rubric, gate, or config schema is restated in this guide — every normative detail
+  is cross-linked to its lane authority.
+
+---
+
+## 7. RELATED / CROSS-LINKS
+
+### Lane-local normative contracts (author to these; do not restate)
+
+| File | What it owns |
+| --- | --- |
+| [`score_dimensions.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/score_dimensions.md) | The five-dimension rubric, weights, and weighted-score threshold |
+| [`evaluator_contract.md`](../../../../system-deep-loop/deep-improvement/references/model_benchmark/evaluator_contract.md) | Scorer/benchmark input-output contract and reject-vs-infra-failure |
+| [`promotion_gate_contract.md`](../../../../system-deep-loop/deep-improvement/references/shared/promotion_gate_contract.md) | The five promotion gates, per-dimension minimums, accept/ship, rollback |
+| [`promotion_rules.md`](../../../../system-deep-loop/deep-improvement/references/shared/promotion_rules.md) | Promotion policy and stop-condition reference |
+| [`stress_test_protocol.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/stress_test_protocol.md) | The same-task A/B stress-test required before promotion claims |
+| [`loop_protocol.md`](../../../../system-deep-loop/deep-improvement/references/shared/loop_protocol.md) | The full INIT/PROPOSE/SCORE/PROMOTE lifecycle the lane runs |
+
+### Lane-local authoring inputs (fill these)
+
+| File | What the author fills |
+| --- | --- |
+| [`improvement_charter.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_charter.md) | Fixed policy scaffold — adopted verbatim, immutable for the run |
+| [`improvement_strategy.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_strategy.md) | Operator-owned goal/hypothesis/focus fields |
+| [`improvement_config.json`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config.json) | `target`, `specFolder`, `lineage.sessionId` in a packet-local copy |
+| [`improvement_config_reference.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/improvement_config_reference.md) | (Read-only) field-by-field config meaning |
+| [`target_manifest.jsonc`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/target_manifest.jsonc) | Optional classification entry and `fixed`/`forbidden` protections |
+| [`candidate_proposal_format.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/candidate_proposal_format.md) | The candidate file shape each proposal follows |
+| [`target_onboarding.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/target_onboarding.md) | Target preconditions and canonical/derived/candidate-only class |
+| [`integration_scanning.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/integration_scanning.md) | The scanned integration surfaces a profile is built from |
+| [`profiling_audit_log.md`](../../../../system-deep-loop/deep-improvement/references/agent_improvement/profiling_audit_log.md) | The profile-selection rationale log shape and retention |
+| [`agent_improvement/README.md`](../../../../system-deep-loop/deep-improvement/assets/agent_improvement/README.md) | Directory map of Lane A data, config, and templates |
+
+### Owning skill and sibling family
+
+- [`deep-improvement SKILL.md`](../../../../system-deep-loop/deep-improvement/SKILL.md) — the mode that owns and runs Lane A (§3).
+- [`model_benchmark_fixture_guide.md`](../model_benchmark/model_benchmark_fixture_guide.md) — the sibling authoring guide for the model-benchmark (Lane B) inputs.
+- [`behavior_benchmark_guide.md`](../behavior_benchmark/behavior_benchmark_guide.md) — the sibling authoring guide for the behavior-benchmark family.
+- [`skill_benchmark_storage_guide.md`](../skill_benchmark/skill_benchmark_storage_guide.md) — the sibling storage guide for the skill-benchmark (Lane C) family.
+- [`../../SKILL.md`](../../SKILL.md) — the `create-benchmark` packet contract for the benchmark families this packet authors.
+
+---
+
+*End of agent-improvement authoring guide — the five-dimension rubric, evaluator
+contract, promotion gates, and code-coupled run config stay lane-local in
+deep-improvement (§3 and §7).*

--- a/.opencode/skills/sk-doc/create-benchmark/references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md
+++ b/.opencode/skills/sk-doc/create-benchmark/references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md
@@ -1,0 +1,261 @@
+---
+title: Non-Dev AI-System Authoring Guide
+description: Authoring guide for the non-dev AI-system (Lane D) inputs - the packaging config an author fills from the example, the fixture and gold-set choices, the grader-calibration selections, and the operator run setup; and which schema, templates, and contracts stay code-owned in deep-improvement and are only cross-linked, never relocated here.
+trigger_phrases:
+  - "non-dev ai system authoring guide"
+  - "lane d authoring guide"
+  - "how to author a packaging config"
+  - "ai-system packaging refine inputs"
+  - "guarded refine authoring"
+importance_tier: normal
+contextType: reference
+version: 1.0.0.0
+---
+
+# Non-Dev AI-System Authoring Guide
+
+Authoring depth for the non-dev AI-system (Lane D) inputs. Lane D is run by
+`/deep:ai-system-improvement` in `system-deep-loop/deep-improvement`; it benchmarks a
+non-dev AI-system *packaging* against an independent grader and auto-refines the
+packaging's technique docs behind hard guardrails. This guide covers what an author
+WRITES to onboard a packaging: the config, the fixture and gold-set choices, the
+grader selections, and the operator run setup. It does NOT restate the loop contract,
+the scoring surface, the grader rubric, or the guardrail teachings — those are
+code-coupled or lane-local in deep-improvement and are cross-linked, never copied.
+Where this guide and a lane contract diverge, the contract prevails.
+
+---
+
+## 1. OVERVIEW: WHAT LANE D AUTHORING COVERS
+
+A Lane D packaging ships one prompt system across runtimes (a CLI runtime, a claude.ai
+Project, and a native skill). To make it refine-able, the packaging implements a
+guarded loop host — `<packaging-root>/benchmark/_loop/loop.py` plus its frozen gates
+and grader — that benchmarks the system with N-sample averaged outputs, re-grades them
+with an independent different-family grader, proposes bounded technique-doc edits, and
+promotes into an isolated git worktree only when held-out grades do not regress.
+
+You do **not** hand-write that loop host. You author a small set of **doc-only inputs**
+and then the scaffolder (`init_packaging.py`) renders the runtime from templates. This
+guide is about those authoring inputs; running, scoring, promoting, and the guardrail
+theory are the lane's job (sections 4 and 8).
+
+### Lane boundary — what stays lane-local or code-owned
+
+| This guide covers (authoring inputs) | Stays in deep-improvement (cross-link, never relocate) |
+| --- | --- |
+| The packaging config you fill from the example | `packaging_config.schema.json` (read by the scaffolder) |
+| Fixture choices: visible / held-out / gold sets | The 9 `templates/*.template` runtime scaffolds |
+| Grader model + gold-set calibration selections | `loop_contract.md` (the loop-host contract) |
+| The operator run setup (env, flags, self-target profile) | `guardrails_teachings.md` and the grader rubric |
+
+Author *to* those contracts; do not re-document them here. This guide names them only
+as wayfinding so an author knows which input feeds which runtime seam.
+
+---
+
+## 2. WHERE THESE LIVE
+
+All Lane D data and contracts sit under the `deep-improvement` mode-packet. Directory
+names use underscores.
+
+| Artifact | Location | Role |
+| --- | --- | --- |
+| Config example (copy this) | [`assets/non_dev_ai_system/packaging_config.example.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.example.json) | The Barter Copywriter pilot config an author copies and rewrites |
+| Config schema (code-owned) | [`assets/non_dev_ai_system/packaging_config.schema.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.schema.json) | The validation contract the scaffolder reads |
+| Runtime templates (code-owned) | [`assets/non_dev_ai_system/templates/`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/templates) | The 9 `*.template` scaffolds rendered by exact filename |
+| Self-target profile | [`assets/non_dev_ai_system/profiles/deep_loop_runtime.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/profiles/deep_loop_runtime.json) | The `frozenSurfaces` / `editableTechDocs` / allow-list profile for self-target runs |
+| Scaffolder | [`scripts/non-dev-ai-system/init_packaging.py`](../../../../system-deep-loop/deep-improvement/scripts/non-dev-ai-system/init_packaging.py) | Renders the runtime into the packaging root from the config |
+| Lane-D references | [`references/non_dev_ai_system/`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md) | Loop contract, fixtures, grader calibration, guardrail teachings, operator guide |
+
+The packaging's rendered runtime (`benchmark/_loop/`, `benchmark/_gates/`,
+`benchmark/grader/`) lands in the packaging root, never back in deep-improvement. Loop
+state (`benchmark/_loop/state/`) is gitignored and hand-authored inputs stay outside it.
+
+---
+
+## 3. AUTHORABLE DOCS (DOC-ONLY)
+
+These are the inputs an author fills or edits. Everything else is generated or
+lane-local.
+
+### 3.1 The packaging config
+
+Copy [`packaging_config.example.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.example.json)
+and rewrite every field for the new system, validating against
+[`packaging_config.schema.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.schema.json).
+The schema's required keys are the author's checklist:
+
+| Field | What you author |
+| --- | --- |
+| `packaging_root` / `system_name` | Absolute path to the packaging and its human-readable name |
+| `dimensions` | Ordered single-letter dimension keys, each with a `floor` and `max` |
+| `score_total` / `ship_threshold` | Max score (e.g. 25) and the auto-ship threshold |
+| `self_score_regex` | Regex that captures the system's self-reported score as group 1 |
+| `frozen_surface` | The scoring docs to content-hash, each with `frozen_name`, `live_relpath`, `section_anchor`, `in_rubric` |
+| `anchors` | Literal strings that must survive in the live scoring docs (erosion tripwire) |
+| `technique_doc_map` | Dimension key -> the ONLY editable technique-doc relpath the proposer may edit |
+| `derived_copies` / `synthesized_surfaces` | Source-to-copy derivations and docs needing human re-derivation |
+| `fixtures` | `visible`, `held_out`, and `variants` id lists (section 3.3) |
+| `models` | `proposer`, `grader`, and the `proposer_family` substring the grader must NOT contain |
+| `harness` | Per-variant `benchmark_mode_instructions` system prompts (`{{CW}}` is the only token) |
+| `lexicon` | `hard_blocker_words` and `hard_blocker_patterns` the deterministic linter enforces |
+
+Self-target runs add `frozenSurfaces`, `editableTechDocs`, `allowedDiffRelpaths`, and
+`excludedSessionPrefixes`; see the self-target profile above for a filled example.
+
+### 3.2 Grader-calibration selections
+
+Pick a `grader` model in a **different family** from the `proposer` (the loop raises a
+kill-switch on a family match), and author a version-locked gold set of human-anchored
+target scores that anchors the grader. The gold outputs and target scores must live
+outside any tree the loop can write. The calibration protocol itself — the `calibrate.py`
+two-grader agreement flow, the `<= 2 / 25` disagreement threshold, phantom-gap tracking,
+and the strict-JSON grader reply shape — is lane-local in
+[`grader_calibration.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/grader_calibration.md).
+Follow it; do not restate it here.
+
+### 3.3 Fixture-authoring choices
+
+Author three fixture tiers and record their ids in `fixtures`:
+
+- **`visible`** — proposer + grader see them; drive gap analysis and iteration targeting.
+- **`held_out`** — grader only; drive the promotion gate. The proposer never sees ids,
+  prompts, or seeds, so held-out seeds live outside any tree the proposer can read.
+- **gold (optional)** — human-anchored calibration anchors, never optimized against.
+
+Every fixture must produce a delimited `<DELIVERABLE>` output and held-out fixtures must
+be sensitive to the dimensions being optimized. The full authoring rules — deliverable
+contract, unpublished adversarial seeds, fixture-lint gating, `N >= 3` sampling — are
+lane-local in
+[`fixture_authoring.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/fixture_authoring.md).
+
+### 3.4 Operator run setup
+
+The run is configured with flags and env knobs, not code. Dry-run is the safe default;
+`--live` is the guarded loop. The knobs (`LOOP_FIXTURES`, `LOOP_VARIANTS`,
+`LOOP_HELD_OUT`, `LOOP_SAMPLES`, `PROPOSER_MODEL`, `GRADER_MODEL`, `LOOP_ACCEPT_MARGIN`,
+`LOOP_POLISH`, `LOOP_LOCK_TTL`, `LOOP_SKIP_PROBE`), the invocation shape, and the
+conformance checklist are documented in
+[`operator_guide.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md).
+
+---
+
+## 4. WHAT STAYS LANE-LOCAL / CODE-OWNED
+
+These are cross-linked, never moved to create-benchmark and never restated here. They
+are read or enforced by runtime code, so a copy would silently drift from the truth.
+
+| Contract | Why it is code-owned | Authority |
+| --- | --- | --- |
+| `packaging_config.schema.json` | Read by `init_packaging.py` to validate the config before rendering | [schema](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.schema.json) |
+| The 9 `templates/*.template` scaffolds | Rendered by `init_packaging.py` by exact filename into the packaging runtime | [templates/](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/templates) |
+| `loop_contract.md` | The formal contract the packaging-owned `loop.py` and `_gates/` implement and enforce | [loop_contract.md](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/loop_contract.md) |
+| `guardrails_teachings.md` | The twelve pilot teachings (T1-T12) and the guardrail each encodes | [guardrails_teachings.md](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/guardrails_teachings.md) |
+
+The 9 rendered scaffolds are `loop.py`, `gauntlet.py`, `gates.py`, `derive.py`,
+`run.sh`, `regrade.py`, `grader_prompt.md`, `deterministic_lint.py`, and `calibrate.py`.
+An author never hand-writes them and never relocates them into this packet — the
+scaffolder owns their filenames and content, and template fixes land in-lane.
+
+---
+
+## 5. AUTHORING WORKFLOW
+
+Complete these in order. The workflow produces inputs and renders the runtime; it never
+runs a live benchmark.
+
+1. **Copy the example config.** Start from `packaging_config.example.json`, never by
+   copy-editing a sibling packaging (a hand-port once disabled floor enforcement via
+   stale dimension keys).
+2. **Fill every field.** Set `dimensions`/floors/maxes, `frozen_surface`, `anchors`,
+   `technique_doc_map`, `derived_copies`, `harness`, and `lexicon`, then validate the
+   config against `packaging_config.schema.json`.
+3. **Choose models.** Set a `proposer` and a different-family `grader`; set
+   `proposer_family` so the grader-family guard can enforce independence.
+4. **Author fixtures.** Declare `visible`, `held_out`, and `variants` per
+   [`fixture_authoring.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/fixture_authoring.md);
+   keep held-out seeds and any gold set outside every loop-writable tree.
+5. **Set up calibration.** Version-lock the gold set and follow
+   [`grader_calibration.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/grader_calibration.md)
+   so the grader agrees within `<= 2 / 25` before it is trusted.
+6. **Render the runtime.** Run
+   `python3 scripts/non-dev-ai-system/init_packaging.py --config <your-config.json> [--check-only]`;
+   it writes `benchmark/_loop/`, `benchmark/_gates/`, and `benchmark/grader/` from the 9
+   templates. Do not hand-write those files.
+7. **Configure the run + conform.** Set the operator env/flags, run the dry-run and the
+   dispatch-free gauntlet, and walk the conformance checklist in
+   [`operator_guide.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md)
+   before any `--live` run.
+
+---
+
+## 6. ALWAYS / NEVER
+
+### ✅ ALWAYS
+
+- Fill a **copy** of `packaging_config.example.json`, validated against the in-lane
+  `packaging_config.schema.json`.
+- Keep held-out seeds and gold outputs version-locked **outside** any tree the loop can
+  write.
+- Pick a grader whose family differs from the proposer, and set `proposer_family` so the
+  guard can enforce it.
+- Render the runtime with `init_packaging.py`; dry-run and pass the gauntlet before
+  `--live`.
+
+### ❌ NEVER
+
+- Hand-relocate the code-read `packaging_config.schema.json`, the 9 `*.template`
+  scaffolds, or `loop_contract.md` into create-benchmark.
+- Hand-write any of the 9 rendered runtime files instead of scaffolding them.
+- Restate the guardrail teachings (`guardrails_teachings.md`) or the grader rubric in
+  this guide.
+- Edit the frozen scoring surface, or copy-edit a sibling packaging to onboard.
+
+---
+
+## 7. SUCCESS CRITERIA
+
+- The config validates against `packaging_config.schema.json` and
+  `init_packaging.py --check-only` is clean.
+- `python3 benchmark/_loop/loop.py --dry-run` exits 0 (gates + grader-family guard + gap
+  analysis).
+- The red-team gauntlet passes its dispatch-free battery (9 attacks, 10 checks, all green).
+- The grader is a different family from the proposer and agrees with the gold set within
+  the calibration threshold.
+- Held-out fixtures produce gradeable `<DELIVERABLE>` output and are sensitive to the
+  optimized dimensions; the gold set is version-locked outside every loop-writable tree.
+
+---
+
+## 8. RELATED / CROSS-LINKS
+
+### Lane-local authorities (author to these; do not restate)
+
+| File | What it owns |
+| --- | --- |
+| [`operator_guide.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md) | Invocation, non-negotiable guardrails, onboarding, conformance checklist |
+| [`loop_contract.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/loop_contract.md) | Required files, argv, env knobs, journal events, kill-switches, lock/resume |
+| [`fixture_authoring.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/fixture_authoring.md) | Visible / held-out / gold fixtures, deliverable contract, N-sample sampling |
+| [`grader_calibration.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/grader_calibration.md) | Different-family requirement, two-grader agreement, phantom gap, gold set |
+| [`guardrails_teachings.md`](../../../../system-deep-loop/deep-improvement/references/non_dev_ai_system/guardrails_teachings.md) | The twelve pilot teachings and the guardrail each encodes |
+
+### Code-owned assets and scaffolder
+
+| Artifact | Role |
+| --- | --- |
+| [`packaging_config.schema.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.schema.json) | Config validation contract read by the scaffolder |
+| [`packaging_config.example.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/packaging_config.example.json) | The pilot config to copy and rewrite |
+| [`templates/`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/templates) | The 9 runtime scaffolds rendered by exact filename |
+| [`profiles/deep_loop_runtime.json`](../../../../system-deep-loop/deep-improvement/assets/non_dev_ai_system/profiles/deep_loop_runtime.json) | Self-target profile (frozen surfaces, editable tech docs, diff allow-list) |
+| [`init_packaging.py`](../../../../system-deep-loop/deep-improvement/scripts/non-dev-ai-system/init_packaging.py) | The scaffolder that renders the runtime from the config |
+
+### Owning skill and sibling family
+
+- [`deep-improvement SKILL.md`](../../../../system-deep-loop/deep-improvement/SKILL.md) — the mode that owns and runs Lane D (`/deep:ai-system-improvement`).
+- [`model_benchmark_fixture_guide.md`](../model_benchmark/model_benchmark_fixture_guide.md) — the sibling Lane B authoring guide in this packet.
+- [`../../SKILL.md`](../../SKILL.md) — the `create-benchmark` packet contract for the benchmark-document families this packet authors.
+
+---
+
+*End of non-dev AI-system authoring guide — the loop contract, scoring surface, grader rubric, and guardrail teachings stay code-owned or lane-local in deep-improvement (sections 4 and 8).*

--- a/.opencode/skills/system-deep-loop/deep-alignment/behavior_benchmark/behavior_benchmark.md
+++ b/.opencode/skills/system-deep-loop/deep-alignment/behavior_benchmark/behavior_benchmark.md
@@ -134,3 +134,4 @@ baseline-derived one.
 - [../README.md](../README.md) — the mode README, whose §5 carries the authoritative availability / build-state note for the `/deep:alignment` surface and its `@deep-alignment` LEAF agent.
 - [../SKILL.md](../SKILL.md) — the mode contract: state machine, adapter contract, and the four alignment invariants these scenarios probe.
 - [./baselines/claude-baseline.md](./baselines/claude-baseline.md) — per-scenario Claude-leg baseline checkpoints (all `pending` until a capture lands).
+- [Authoring: ../../../sk-doc/create-benchmark/references/behavior_benchmark/behavior_benchmark_guide.md](../../../sk-doc/create-benchmark/references/behavior_benchmark/behavior_benchmark_guide.md) — the behavior-benchmark authoring guide (create-benchmark §9): how to author this package's index, scenarios, and baseline. Templates and authoring standards live there; this package instantiates the framework above.

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/agent_improvement/README.md
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/agent_improvement/README.md
@@ -68,3 +68,4 @@ Expected result: the command exits 0, confirming `improvement_config.json` is va
 - [`scripts/agent-improvement README`](../../scripts/README.md)
 - [`model-benchmark README`](../../scripts/model-benchmark/README.md)
 - [`deep-improvement SKILL.md`](../../SKILL.md)
+- [`Authoring: agent_improvement_authoring_guide.md`](../../../../sk-doc/create-benchmark/references/agent_improvement/agent_improvement_authoring_guide.md) — how to author these Lane A inputs (create-benchmark). The rubric, config schema, and run logic stay here in-lane and are cross-linked, never relocated.

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "model-vs-model",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": [
     "hard_merge_intervals",
     "hard_parse_csv_line",

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo_v2.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo_v2.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "model-vs-model",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": [
     "harder_semver_compare",
     "harder_normalize_path",

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo_v3.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/capability_m3_vs_mimo_v3.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "model-vs-model",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": [
     "validate_ipv4",
     "validate_date",

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/default.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/default.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "targetPath": ".opencode/agents/deep-improvement.md",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["fixture_baseline", "fixture_improved", "fixture_edge"],
   "outputsDir": "{spec_folder}/improvement/benchmark-outputs",
   "metrics": ["score", "delta", "pass_rate"],

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/framework_bakeoff.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/framework_bakeoff.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "framework-bakeoff",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["t3-lower-bound", "t3-compare-versions"],
   "fixtureSelection": {
     "include": ["t3-lower-bound", "t3-compare-versions"],

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/glm_5.2_frameworks.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/glm_5.2_frameworks.json
@@ -5,7 +5,7 @@
   "family": "deep-improvement",
   "mode": "framework-bakeoff",
   "_note": "GLM-5.2 framework bakeoff (157-glm-5-2-support/002). Uses the invalid-dominant strict-validator pack from the start (the 149 run-007 lesson) so correctness SEPARATES instead of saturating. Frameworks are limited to the harness framework-registry set [rcaf,race,cidi,tidd-ec,costar]; CRAFT (the phase-1 doc-guided default) is NOT in the registry, so the empirical winner among these 5 replaces it. correctnessGate.threshold 0.0 ranks groups on graded correctness_pass_rate (deterministic oracle) rather than filtering. Ran with --grader noop so correctness comes from the deterministic hidden-test oracle with no LLM-judge bias.",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["validate_ipv4", "validate_date", "validate_semver"],
   "fixtureSelection": {
     "include": ["validate_ipv4", "validate_date", "validate_semver"]

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/kimi_k2.7_discriminating.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/kimi_k2.7_discriminating.json
@@ -5,7 +5,7 @@
   "family": "deep-improvement",
   "mode": "framework-bakeoff",
   "_note": "Discriminating re-run of the kimi-k2.7-code framework bakeoff. Run 006 (kimi-k2.7-frameworks.json) used easy T3 fixtures that saturated a frontier model (all frameworks correctness 1.0 -> TIE). This profile uses the invalid-dominant strict-validator pack (the fixtures README's designed discriminators) so a lax solution scores <1.0 and correctness VARIES by framework, plus more samples for CI power. correctnessGate.threshold is lowered to 0.0 so frameworks are ranked on graded correctness_pass_rate rather than filtered.",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["validate_ipv4", "validate_date", "validate_semver", "hard_roman_to_int"],
   "fixtureSelection": {
     "include": ["validate_ipv4", "validate_date", "validate_semver", "hard_roman_to_int"],

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/kimi_k2.7_frameworks.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/kimi_k2.7_frameworks.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "framework-bakeoff",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["t3-lower-bound", "t3-compare-versions"],
   "fixtureSelection": {
     "include": ["t3-lower-bound", "t3-compare-versions"],

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/model_vs_model.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/model_vs_model.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "model-vs-model",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": ["t3-lower-bound", "t3-compare-versions"],
   "fixtureSelection": {
     "include": ["t3-lower-bound", "t3-compare-versions"],

--- a/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/reviewer_regression.json
+++ b/.opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/reviewer_regression.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "family": "deep-improvement",
   "mode": "reviewer",
-  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark-fixtures",
+  "fixtureDir": ".opencode/skills/system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_fixtures",
   "fixtures": [
     "reviewer_stale_verdict",
     "reviewer_softened_fail",

--- a/.opencode/skills/system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md
+++ b/.opencode/skills/system-deep-loop/deep-improvement/references/non_dev_ai_system/operator_guide.md
@@ -126,3 +126,4 @@ Barter Copywriter: `/Users/michelkerkmeester/MEGA/Development/AI_Systems/Barter/
 - [guardrails_teachings.md](./guardrails_teachings.md) — the twelve pilot teachings and their guardrail encodings
 - [fixture_authoring.md](./fixture_authoring.md) — how to author visible, held-out and gold fixtures
 - [grader_calibration.md](./grader_calibration.md) — the calibration protocol for independent graders
+- [Authoring: non_dev_ai_system_authoring_guide.md](../../../../sk-doc/create-benchmark/references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md) — how to author these Lane D inputs (create-benchmark). The packaging schema, the nine templates, and the loop contract are code-owned here in-lane and are cross-linked, never relocated.

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/checklist.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/checklist.md
@@ -1,0 +1,103 @@
+---
+title: "Checklist: Benchmark Authoring Completion and Cross-Links"
+description: "QA checklist verifying the Lane A/D authoring guides, bidirectional benchmark cross-links, and the metadata/sibling/fixtureDir corrections, with no lane-owned relocation or run/scoring change."
+trigger_phrases:
+  - "benchmark authoring completion checklist"
+importance_tier: "important"
+contextType: "implementation"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "Checklist verified against gate output"
+    next_safe_action: "Commit"
+    blockers: []
+---
+# Verification Checklist: Benchmark Authoring Completion and Cross-Links
+
+<!-- SPECKIT_TEMPLATE_SOURCE: checklist-core | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+<!-- ANCHOR:protocol -->
+## Verification Protocol
+
+Mark `[x]` only with evidence (command output, file:line, or grep result). Do not claim completion without running the stated check.
+<!-- /ANCHOR:protocol -->
+
+---
+
+<!-- ANCHOR:pre-impl -->
+## Pre-Implementation
+
+- [x] CHK-001 [P0] Move map and blast radius established by two read-only audits (deep-improvement inventory + deep-alignment/shared cross-links); recorded in `plan.md` §1 Technical Context.
+- [x] CHK-002 [P0] Operator ruling recorded in `decision-record.md` ADR-002: contracts stay lane-owned, cross-linked (no relocation).
+<!-- /ANCHOR:pre-impl -->
+
+---
+
+<!-- ANCHOR:code-quality -->
+## Code Quality
+
+- [x] CHK-010 [P0] Both guides cross-link lane authorities, no rubric restated (`rg` shows dimensions named, weights/thresholds linked to `score_dimensions.md`).
+- [x] CHK-011 [P0] SKILL edits word-neutral; word count `4996` of `5000` cap, confirmed by `package_skill.py create-benchmark --check` (PASS).
+<!-- /ANCHOR:code-quality -->
+
+---
+
+<!-- ANCHOR:testing -->
+## Testing
+
+- [x] CHK-020 [P0] `validate_document.py` reports 0 issues on both guides and the changelog.
+- [x] CHK-021 [P0] `package_skill.py create-benchmark --check` reports PASS.
+- [x] CHK-022 [P1] All new lane->hub back-pointer relative paths resolve `3/3` via `ls` (deep-alignment, laneA, laneD).
+- [x] CHK-023 [P0] `validate.sh --strict` reports Errors:0 on this child (see close-out run).
+<!-- /ANCHOR:testing -->
+
+---
+
+<!-- ANCHOR:fix-completeness -->
+## Fix Completeness
+
+- [x] CHK-030 [P0] All 10 model-benchmark profiles resolve `fixtureDir` (`test -d` OK ×10; `rg -l benchmark-fixtures *.json` → 0).
+- [x] CHK-031 [P1] No `016-benchmark-authoring` in live metadata/continuity (`rg` returns only frozen `../review/**`).
+- [x] CHK-032 [P1] Parent `spec.md` sibling reference resolves (`grep -n Sibling spec.md` → points at existing 017/018 with a renumber note).
+- [x] CHK-033 [P1] deep-alignment + Lane A + Lane D back-pointers present (`rg create-benchmark deep-alignment` >= 1).
+<!-- /ANCHOR:fix-completeness -->
+
+---
+
+<!-- ANCHOR:security -->
+## Security
+
+- [x] CHK-040 [P1] No credentials, secrets, or external calls introduced; changes are documentation, config-path, and metadata only (`git diff --stat` → no code or secret files).
+<!-- /ANCHOR:security -->
+
+---
+
+<!-- ANCHOR:docs -->
+## Documentation
+
+- [x] CHK-050 [P1] Two authoring guides added; six-family coverage in SKILL `§2` and `changelog/v1.3.0.0.md`.
+- [x] CHK-051 [P1] Decision record captures the amendment/reaffirmation in `decision-record.md` ADR-001 (amends parent ADR-003) and ADR-002 (reaffirms parent ADR-004).
+- [x] CHK-052 [P1] `implementation-summary.md` written; parent phase map updated with the child 002 row (see close-out).
+<!-- /ANCHOR:docs -->
+
+---
+
+<!-- ANCHOR:file-org -->
+## File Organization
+
+- [x] CHK-060 [P1] Guides placed under `references/{agent_improvement,non_dev_ai_system}/` per the family layout.
+- [x] CHK-061 [P0] No `../review/**` frozen evidence modified; no run/scoring code, contract, schema, or code-coupled template touched (`git diff --stat`).
+<!-- /ANCHOR:file-org -->
+
+---
+
+<!-- ANCHOR:summary -->
+## Verification Summary
+
+- [x] CHK-070 [P1] `git diff --stat` reviewed against the scope list; zero out-of-scope changes (see close-out).
+- [x] CHK-071 [P0] `validate.sh --strict` Errors:0 recorded; child `description.json` + `graph-metadata.json` generated.
+- [x] CHK-072 [P1] All success criteria `SC-001..SC-005` in `spec.md` §5 met (evidence in the `implementation-summary.md` Verification table).
+<!-- /ANCHOR:summary -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/decision-record.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/decision-record.md
@@ -1,0 +1,61 @@
+---
+title: "Decision Record: Benchmark Authoring Completion and Cross-Links"
+description: "ADRs for completing benchmark-authoring centralization: create-benchmark hosts the authoring GUIDE for every family (amending the Lane A/D non-goal decision); code-coupled artifacts and measurement contracts stay lane-owned and cross-linked (reaffirming the contracts ruling); the fixtureDir break is a systemic correctness fix."
+trigger_phrases:
+  - "benchmark authoring completion decisions"
+importance_tier: "important"
+contextType: "decision"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "ADRs recorded"
+    next_safe_action: "Implement per ADRs"
+---
+# Decision Record: Benchmark Authoring Completion and Cross-Links
+
+<!-- SPECKIT_TEMPLATE_SOURCE: decision-record | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+---
+
+<!-- ANCHOR:adr-001 -->
+## ADR-001: create-benchmark hosts an authoring GUIDE for every family; Lane A and Lane D are no longer pure non-goals (amends parent ADR-003)
+
+**Status:** Accepted
+
+**Context:** Parent ADR-003 declared Lane A (agent-improvement) and Lane D (non-dev-ai-system) code-owned non-goals, so create-benchmark carried no authoring content for them. But both own real doc-only authoring surfaces, and a create-benchmark reader was silently missing two of six families. The operator asked to make create-benchmark the single home for benchmark document-creation guidelines.
+
+**Decision:** create-benchmark hosts an authoring GUIDE for every family, including new Lane A and Lane D guides. The guides teach how to author the doc-only inputs and cross-link the lane-owned artifacts. This amends ADR-003: Lane A/D are now "authoring-guided here," not non-goals. Their executable/code-coupled artifacts remain in-lane (see ADR-002).
+
+**Consequences:** The family router in create-benchmark §2 is complete at the guidance layer — six families, one home for "how do I author this." Cost: two families are guide-only here (their fillable templates/configs stay in-lane), an intentional asymmetry recorded in ADR-002.
+<!-- /ANCHOR:adr-001 -->
+
+---
+
+<!-- ANCHOR:adr-002 -->
+## ADR-002: Measurement contracts and code-coupled artifacts stay lane-owned and cross-linked; nothing is relocated (reaffirms parent ADR-004)
+
+**Status:** Accepted
+
+**Context:** The operator was offered three tiers, including physically relocating scoring/measurement contracts (and the code-read schema/templates/config) into create-benchmark. Audit showed several targets are read by executable code and tests (`packaging_config.schema.json` and the 9 `templates/*.template` by `init_packaging.py`; `loop_contract.md` by a runtime vitest; `improvement_config.json` by `dispatch-model.cjs`), and the four core contracts state verbatim "never copied into create-benchmark." Relocation would break the build and invert run-ownership (a documentation skill owning the runners' measurement truth).
+
+**Decision:** Reaffirm parent ADR-004 and extend it to code-coupled artifacts. No contract, rubric, schema, scorer, runner, or code-read template moves into create-benchmark. create-benchmark achieves "single home" at the authoring-GUIDANCE layer and cross-links the lane authorities bidirectionally.
+
+**Consequences:** No build breakage; run/scoring ownership stays with the lanes that execute. "Single home" means single home for authoring guidance, not physical custody of every artifact. The operator selected this over the two relocation tiers.
+<!-- /ANCHOR:adr-002 -->
+
+---
+
+<!-- ANCHOR:adr-003 -->
+## ADR-003: The fixtureDir break is a systemic profile correction, not a reviewer-only fix
+
+**Status:** Accepted
+
+**Context:** Parent packet 015 flagged F002 as a single reviewer-profile pointing at a nonexistent hyphenated `benchmark-fixtures` directory. Audit found all 10 model-benchmark profiles carry the same `fixtureDir`, and `run-benchmark.cjs` resolves the path directly with no hyphen->underscore normalization — so the underscore-migration silently broke every profile's default fixture path, not one.
+
+**Decision:** Repoint all 10 profiles and reconcile the profiles README prose in one correction. This is a data/config fix in the deep-improvement lane, touching no run/scoring logic.
+
+**Consequences:** Lane B's shipped default fixture path resolves again for every profile. The fix lives in-lane (the profiles are lane data); create-benchmark is unaffected.
+<!-- /ANCHOR:adr-003 -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/description.json
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/description.json
@@ -1,0 +1,29 @@
+{
+  "level": "2",
+  "specFolder": "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks",
+  "description": "Parent packet 015 made `sk-doc/create-benchmark` the single home for benchmark-document templates and standards for four families (MCP promotion,",
+  "keywords": [
+    "parent",
+    "packet",
+    "sk-doc",
+    "create-benchmark",
+    "single",
+    "home",
+    "benchmark-document",
+    "templates",
+    "standards",
+    "four",
+    "families",
+    "mcp",
+    "promotion"
+  ],
+  "lastUpdated": "2026-07-13T14:35:28.444Z",
+  "specId": "002",
+  "folderSlug": "benchmark-authoring-completion-and-crosslinks",
+  "parentChain": [
+    "sk-doc",
+    "016-benchmark-authoring-centralization"
+  ],
+  "memorySequence": 0,
+  "memoryNameHistory": []
+}

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/graph-metadata.json
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/graph-metadata.json
@@ -1,0 +1,218 @@
+{
+  "schema_version": 1,
+  "packet_id": "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks",
+  "spec_folder": "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks",
+  "parent_id": "sk-doc/016-benchmark-authoring-centralization",
+  "children_ids": [],
+  "manual": {
+    "depends_on": [],
+    "supersedes": [],
+    "related_to": []
+  },
+  "derived": {
+    "trigger_phrases": [
+      "benchmark authoring completion",
+      "lane a lane d authoring guide create-benchmark",
+      "benchmark cross-link deep-alignment",
+      "benchmark authoring completion plan",
+      "benchmark authoring completion tasks",
+      "benchmark authoring completion checklist",
+      "benchmark authoring completion decisions",
+      "benchmark authoring completion summary"
+    ],
+    "key_topics": [
+      "benchmark",
+      "authoring",
+      "completion",
+      "lane",
+      "guide",
+      "create-benchmark",
+      "cross-link",
+      "deep-alignment",
+      "plan",
+      "tasks",
+      "checklist",
+      "decisions"
+    ],
+    "importance_tier": "important",
+    "status": "complete",
+    "key_files": [
+      "decision-record.md",
+      "spec.md",
+      "implementation-summary.md",
+      "plan.md",
+      "tasks.md",
+      "checklist.md"
+    ],
+    "entities": [
+      {
+        "name": "decision-record.md",
+        "kind": "doc",
+        "path": "decision-record.md",
+        "source": "derived"
+      },
+      {
+        "name": "spec.md",
+        "kind": "doc",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "implementation-summary.md",
+        "kind": "doc",
+        "path": "implementation-summary.md",
+        "source": "derived"
+      },
+      {
+        "name": "plan.md",
+        "kind": "doc",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "tasks.md",
+        "kind": "doc",
+        "path": "tasks.md",
+        "source": "derived"
+      },
+      {
+        "name": "checklist.md",
+        "kind": "doc",
+        "path": "checklist.md",
+        "source": "derived"
+      },
+      {
+        "name": "Feature Specification",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "Benchmark Authoring Completion",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "Author Lane",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "In Progress",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "Parent Spec",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "Problem Statement Parent",
+        "kind": "proper_noun",
+        "path": "spec.md",
+        "source": "derived"
+      },
+      {
+        "name": "Implementation Plan",
+        "kind": "proper_noun",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "Execute Phase",
+        "kind": "proper_noun",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "Technical Context Two",
+        "kind": "proper_noun",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "Overview Author",
+        "kind": "proper_noun",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "Key Components",
+        "kind": "proper_noun",
+        "path": "plan.md",
+        "source": "derived"
+      },
+      {
+        "name": "Task Notation",
+        "kind": "proper_noun",
+        "path": "tasks.md",
+        "source": "derived"
+      },
+      {
+        "name": "Add Lane",
+        "kind": "proper_noun",
+        "path": "tasks.md",
+        "source": "derived"
+      },
+      {
+        "name": "Completion Criteria All",
+        "kind": "proper_noun",
+        "path": "tasks.md",
+        "source": "derived"
+      },
+      {
+        "name": "evidence",
+        "kind": "key_phrase",
+        "path": "tasks.md",
+        "source": "derived"
+      },
+      {
+        "name": "Verification Checklist",
+        "kind": "proper_noun",
+        "path": "checklist.md",
+        "source": "derived"
+      },
+      {
+        "name": "Verification Protocol Mark",
+        "kind": "proper_noun",
+        "path": "checklist.md",
+        "source": "derived"
+      },
+      {
+        "name": "Technical Context",
+        "kind": "proper_noun",
+        "path": "checklist.md",
+        "source": "derived"
+      }
+    ],
+    "causal_summary": "Parent packet 015 made `sk-doc/create-benchmark` the single home for benchmark-document templates and standards for four families (MCP promotion, behavior, skill-benchmark, model-benchmark)",
+    "created_at": "2026-07-13T13:14:44.226Z",
+    "last_save_at": "2026-07-13T14:35:28.767Z",
+    "save_lineage": "graph_only",
+    "last_accessed_at": null,
+    "source_docs": [
+      "spec.md",
+      "plan.md",
+      "tasks.md",
+      "checklist.md",
+      "decision-record.md",
+      "implementation-summary.md"
+    ],
+    "source_fingerprint": "sha256:be89bcdd8cc88b68fd64c301fa692f30495aa877f6f8f1d204a6c2a431b266c1",
+    "source_doc_hashes": {
+      "spec.md": "1724e3516a1e738bc65f21d4024cefb8daf0d0c8df72685ad12d15ad3bbdc61e",
+      "plan.md": "0ac931d733576390622d77d57bc0b3d188909882fae2f2b533c2d3e240b3f7e8",
+      "tasks.md": "90d2d9e98a4b1d28217f436a4aee6ab76982bc261b58185756b0819a6091e22a",
+      "checklist.md": "47bb70af313eaf53c882c846a672e2a7d38bb20cdfa3920673d62c2b5f67a60a",
+      "decision-record.md": "f5245e42c15bbb7085e8aedfeecee5a82de91ce9b268f1caa8956997b4e7423c",
+      "implementation-summary.md": "09de73e5fc9eb982bc9cbfb5ac9828ca4d9810b785ed286e2b4fcfa928a0691f"
+    },
+    "last_active_child_id": null,
+    "last_active_at": null
+  }
+}

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/implementation-summary.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/implementation-summary.md
@@ -1,0 +1,120 @@
+---
+title: "Implementation Summary: Benchmark Authoring Completion and Cross-Links"
+description: "Authored the Lane A (agent-improvement) and Lane D (non-dev-ai-system) authoring guides in sk-doc/create-benchmark, giving the packet six-family authoring coverage; completed the create-benchmark <-> deep-loop bidirectional link mesh; and landed three carried-over corrections (016->015 identity, dangling sibling, systemic fixtureDir break across 10 profiles). No lane-owned contract, schema, or code-coupled template was relocated; no run/scoring logic changed."
+trigger_phrases:
+  - "benchmark authoring completion summary"
+importance_tier: "important"
+contextType: "implementation"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "Guides authored, links completed, three fixes landed; gates run"
+    next_safe_action: "Final strict validation and commit"
+    blockers: []
+    completion_pct: 100
+    status: "Complete"
+    open_questions: []
+    answered_questions: []
+---
+# Implementation Summary
+
+<!-- SPECKIT_TEMPLATE_SOURCE: impl-summary-core + level2-verify | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+---
+
+<!-- ANCHOR:metadata -->
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Spec Folder** | 002-benchmark-authoring-completion-and-crosslinks |
+| **Completed** | 2026-07-13 |
+| **Level** | 2 |
+| **Parent Spec** | ../spec.md |
+<!-- /ANCHOR:metadata -->
+
+---
+
+<!-- ANCHOR:what-built -->
+## What Was Built
+
+create-benchmark is now the single home for benchmark-document authoring guidance across all six families, with a complete bidirectional link mesh to the deep-loop lanes that run and score.
+
+| Artifact | Purpose |
+|---|---|
+| `references/agent_improvement/agent_improvement_authoring_guide.md` | Lane A (agent-improvement) authoring guide — charter/strategy/onboarding/candidate/profiling inputs; cross-links the 5-dim rubric, evaluator contract, promotion gate, and code-coupled config |
+| `references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md` | Lane D (non-dev-ai-system) authoring guide — packaging config, fixture/gold-set choices, grader calibration, operator setup; cross-links the code-owned schema, 9 templates, and loop contract |
+| `SKILL.md` §1/§2/§12 + `version` 1.3.0.0 | Six-family table (Lane A/D now name their guide), reworded framing, REFERENCES rows; word-neutral under the 5000-word cap |
+| `changelog/v1.3.0.0.md` | Release note for the two guides and the completed link mesh |
+| 3 lane->hub back-pointers | `deep-alignment/behavior_benchmark/behavior_benchmark.md` (its first create-benchmark reference), Lane A `assets/agent_improvement/README.md`, Lane D `references/non_dev_ai_system/operator_guide.md` |
+| 10 model-benchmark profile JSONs + README | `fixtureDir` repointed `benchmark-fixtures`->`benchmark_fixtures` (systemic F002 fix) |
+| Parent + child metadata / continuity | `016`->`015` packet-identity normalization; parent sibling reference corrected |
+<!-- /ANCHOR:what-built -->
+
+---
+
+<!-- ANCHOR:how-delivered -->
+## How It Was Delivered
+
+Two read-only audits (deep-improvement inventory + blast radius; deep-alignment/shared + cross-links) established the move map and confirmed no code-reader would break. The two guides were drafted in parallel by template-first agents against a proven exemplar, each self-validated to 0 issues, then independently re-verified in the main loop. The three fixes were applied as scoped, verifiable edits. The SKILL was integrated by hand under a strict word budget. All gates were run before the completion claim.
+<!-- /ANCHOR:how-delivered -->
+
+---
+
+<!-- ANCHOR:decisions -->
+## Key Decisions
+
+Recorded as ADR-001..003 in `./decision-record.md`: create-benchmark hosts an authoring guide for every family, amending parent ADR-003's Lane A/D non-goal stance (001); measurement contracts and code-coupled artifacts stay lane-owned and cross-linked, reaffirming parent ADR-004 — selected by the operator over two relocation tiers after the audit surfaced build-breaking code readers and an ownership inversion (002); the fixtureDir break is a systemic 10-profile correction, not the reviewer-only fix parent 015 recorded (003).
+<!-- /ANCHOR:decisions -->
+
+---
+
+<!-- ANCHOR:verification -->
+## Verification
+
+| Check | Result |
+|---|---|
+| `validate_document.py` on both guides + changelog | 0 issues each |
+| `package_skill.py create-benchmark --check` | PASS (SKILL 4996 words, under the 5000 cap) |
+| 3 new lane->hub back-pointer relative paths | All resolve (`ls`) |
+| 10 model-benchmark `fixtureDir` | All resolve to `benchmark_fixtures`; 0 hyphen refs remain |
+| Live `016` identity | Cleared; only frozen `../review/**` retains it |
+| create-benchmark markdown link check | No new broken links (only the pre-existing illustrative template placeholder) |
+| Lane-owned contract/schema/template/run-logic diff | None |
+<!-- /ANCHOR:verification -->
+
+---
+
+<!-- ANCHOR:nfr-verify -->
+## NFR Verification
+
+| NFR ID | Target | Actual | Status |
+|--------|--------|--------|--------|
+| NFR-M01 | Every family has a discoverable authoring home | Six families routable from SKILL §2 | Pass |
+| NFR-M02 | Lane contracts stay single-source | Cross-linked, never copied | Pass |
+| NFR-R01 | No run/scoring behavior change | fixtureDir fix restores a broken default path only | Pass |
+<!-- /ANCHOR:nfr-verify -->
+
+---
+
+<!-- ANCHOR:limitations -->
+## Known Limitations
+
+- The pre-existing illustrative placeholder link in `assets/behavior_benchmark/behavior_benchmark_index_template.md` (`./baselines/claude-baseline.md`) resolves only in a filled instance; unchanged and out of scope, as noted in child 001.
+- The two doc-only Lane A templates (`improvement_charter.md`, `improvement_strategy.md`) stay in-lane and are guided+linked, not relocated — a deferred operator follow-up.
+- Repo-wide markdown link check surfaces pre-existing broken links in other skills (sk-prompt, deep-review) from a concurrent migration; out of scope here.
+<!-- /ANCHOR:limitations -->
+
+---
+
+<!-- ANCHOR:deviations -->
+## Deviations from Plan
+
+| Planned | Actual | Reason |
+|---------|--------|--------|
+| Packet at Level 3 | Level 2 | Scope matches the Level-2 sibling child 001 (doc-authoring + fixes, no logic change); Level 3 demanded AI-protocol sections not warranted here. |
+| Fix F002 as a single reviewer profile | Fixed all 10 model-benchmark profiles | Audit proved the hyphen `fixtureDir` is systemic and `run-benchmark.cjs` resolves it directly with no normalization. |
+<!-- /ANCHOR:deviations -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/plan.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/plan.md
@@ -1,0 +1,158 @@
+---
+title: "Implementation Plan: Benchmark Authoring Completion and Cross-Links"
+description: "Phased plan to author the Lane A and Lane D authoring guides, complete the create-benchmark <-> deep-loop bidirectional links, and land the 016->015 metadata, sibling, and fixtureDir corrections, without relocating any lane-owned contract."
+trigger_phrases:
+  - "benchmark authoring completion plan"
+importance_tier: "important"
+contextType: "implementation"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "Plan authored"
+    next_safe_action: "Execute Phase 1 fixes"
+    blockers: []
+---
+# Implementation Plan: Benchmark Authoring Completion and Cross-Links
+
+<!-- SPECKIT_TEMPLATE_SOURCE: plan-core | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+---
+
+<!-- ANCHOR:summary -->
+## 1. SUMMARY
+
+### Technical Context
+Two read-only audits established the move map. The four already-authored families keep their templates/guides in create-benchmark; nothing migrates from deep-alignment (its `behavior_benchmark/` is all filled instances). The shared `framework.md` and the four measurement contracts have no code readers but are run/scoring authorities; per operator ruling they stay lane-owned and are cross-linked. Lane D has hard code-reader coupling on `packaging_config.schema.json`, the 9 `templates/*.template`, and `loop_contract.md`; Lane A on `improvement_config.json`. create-benchmark SKILL.md is at the 5000-word cap, so new detail lands in reference guides.
+
+### Overview
+Author two family guides, integrate them into the SKILL word-neutrally, complete the bidirectional links, and land the three carried-over corrections — all without moving a lane-owned artifact.
+<!-- /ANCHOR:summary -->
+
+---
+
+<!-- ANCHOR:quality-gates -->
+## 2. QUALITY GATES
+
+### Definition of Ready
+- Move map and blast radius established by audit; operator ruling recorded (contracts stay lane-owned).
+- Target paths and cross-link authorities enumerated.
+
+### Definition of Done
+- `validate_document.py` 0 issues on new/changed docs; `package_skill.py create-benchmark --check` PASS.
+- `validate.sh --strict` Errors:0 on this child; no run/scoring or contract diff.
+<!-- /ANCHOR:quality-gates -->
+
+---
+
+<!-- ANCHOR:architecture -->
+## 3. ARCHITECTURE
+
+### Pattern
+create-benchmark owns benchmark-authoring GUIDANCE; the deep-loop lanes own run/scoring. Guides cross-link the lane authorities bidirectionally, never restating or relocating them.
+
+### Key Components
+- create-benchmark reference guides (per family) + the §2 family router.
+- deep-improvement lane contracts, schemas, and code-coupled templates (unchanged).
+- The bidirectional link mesh between the two trees.
+
+### Data Flow
+An author enters at create-benchmark §2, routes to a family guide, and follows links into the lane for the normative contract. A lane reader finds the authoring guide via the lane->hub back-pointer.
+<!-- /ANCHOR:architecture -->
+
+---
+
+<!-- ANCHOR:affected-surfaces -->
+## FIX ADDENDUM: AFFECTED SURFACES
+
+- `sk-doc/create-benchmark/**` — two new guides, SKILL §1/§2/§12, changelog, version.
+- `system-deep-loop/deep-alignment/behavior_benchmark/behavior_benchmark.md` — one back-pointer bullet.
+- `system-deep-loop/deep-improvement/assets/agent_improvement/README.md` and `references/non_dev_ai_system/operator_guide.md` — one back-pointer each.
+- `system-deep-loop/deep-improvement/assets/model_benchmark/benchmark_profiles/*.json` — fixtureDir repoint (data only).
+- `specs/sk-doc/016-benchmark-authoring-centralization/**` (excl. `review/**`) — identity + sibling corrections.
+<!-- /ANCHOR:affected-surfaces -->
+
+---
+
+<!-- ANCHOR:phases -->
+## 4. IMPLEMENTATION PHASES
+
+### Phase 1: Setup
+Land the carried-over corrections (fixtureDir, packet identity, sibling) — independent and low-risk.
+
+### Phase 2: Core Implementation
+Author the two family guides; integrate them into the SKILL word-neutrally (family table, §1, §12, version, changelog); complete the three lane->hub back-pointers.
+
+### Phase 3: Verification
+Run `validate_document.py`, `package_skill.py --check`, link check, and `validate.sh --strict`; generate child metadata; write the implementation summary; reconcile the parent phase map.
+<!-- /ANCHOR:phases -->
+
+---
+
+<!-- ANCHOR:testing -->
+## 5. TESTING STRATEGY
+
+- Link-not-copy grep on each guide.
+- Word-count measurement before/after each SKILL edit.
+- No-regression: `git diff --stat` reviewed against the scope list; zero diff under run/scoring code, contracts, templates, deep-alignment engine.
+- Path resolution: every new back-pointer and every profile `fixtureDir` resolves on disk.
+<!-- /ANCHOR:testing -->
+
+---
+
+<!-- ANCHOR:dependencies -->
+## 6. DEPENDENCIES
+
+- Parent 015 family-section shape (mirrored by the new guides).
+- Operator ruling: contracts stay lane-owned, cross-linked.
+- sk-doc shared validators (`validate_document.py`, `package_skill.py`) and the spec validator.
+<!-- /ANCHOR:dependencies -->
+
+---
+
+<!-- ANCHOR:rollback -->
+## 7. ROLLBACK PLAN
+
+All edits are additive docs, one-line back-pointers, a mechanical config path fix, and metadata normalization. Rollback is `git checkout` of the changed paths; no data migration or destructive move is involved.
+<!-- /ANCHOR:rollback -->
+
+---
+
+<!-- ANCHOR:phase-deps -->
+## L2: PHASE DEPENDENCIES
+
+- Phase 1 is independent of Phases 2-3.
+- The two guides (Phase 2) precede the SKILL §12 links and the lane->hub back-pointers (targets must exist first).
+- Metadata generation and the parent phase-map update (Phase 3) run last.
+<!-- /ANCHOR:phase-deps -->
+
+---
+
+<!-- ANCHOR:effort -->
+## L2: EFFORT ESTIMATION
+
+| Workstream | Estimate | Notes |
+|-----------|----------|-------|
+| Two family guides | Moderate | Parallel authoring against a proven exemplar; validate each. |
+| SKILL integration | Small | Word-neutral edits under a hard cap. |
+| Links + three fixes | Small | Mechanical; verified by grep/resolution. |
+| Gates + close-out | Small | Validators + metadata + summary. |
+<!-- /ANCHOR:effort -->
+
+---
+
+<!-- ANCHOR:enhanced-rollback -->
+## L2: ENHANCED ROLLBACK
+
+### Pre-deployment Checklist
+- Confirm no diff under run/scoring code, contracts, code-coupled templates, or deep-alignment engine dirs.
+- Confirm SKILL word count <= cap and `--check` PASS.
+
+### Rollback Procedure
+- `git checkout -- <changed paths>` restores the prior state; the changes are non-destructive.
+
+### Data Reversal
+- None required; no data migration, deletion, or schema change is performed.
+<!-- /ANCHOR:enhanced-rollback -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/spec.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/spec.md
@@ -1,0 +1,179 @@
+---
+title: "Feature Specification: Benchmark Authoring Completion and Cross-Links"
+description: "Finish making sk-doc/create-benchmark the single home for benchmark-document authoring guidance across all six families: author the missing Lane A (agent-improvement) and Lane D (non-dev-ai-system) authoring guides, promote both from code-owned non-goals to authoring-guided-here (code artifacts stay in-lane), complete the bidirectional create-benchmark <-> deep-loop links (deep-alignment back-pointer + Lane A/D lane->hub pointers), and land three carried-over corrections: the 016->015 packet-identity drift, the dangling sibling reference, and the systemic model-benchmark fixtureDir path break."
+trigger_phrases:
+  - "benchmark authoring completion"
+  - "lane a lane d authoring guide create-benchmark"
+  - "benchmark cross-link deep-alignment"
+importance_tier: "important"
+contextType: "implementation"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "Packet scaffolded; scope frozen after two read-only audits"
+    next_safe_action: "Author Lane A/D guides, apply the three fixes, complete links, run gates"
+    blockers: []
+    completion_pct: 0
+    open_questions: []
+    answered_questions:
+      - "Contracts stay lane-owned and cross-linked (operator ruling); no relocation"
+---
+# Feature Specification: Benchmark Authoring Completion and Cross-Links
+
+<!-- SPECKIT_TEMPLATE_SOURCE: spec-core | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+---
+
+<!-- ANCHOR:metadata -->
+## 1. METADATA
+
+| Field | Value |
+|-------|-------|
+| **Level** | 2 |
+| **Priority** | P1 |
+| **Status** | In Progress |
+| **Created** | 2026-07-13 |
+| **Track** | sk-doc |
+| **Parent** | `sk-doc/016-benchmark-authoring-centralization` |
+| **Parent Spec** | ../spec.md |
+<!-- /ANCHOR:metadata -->
+
+---
+
+<!-- ANCHOR:problem -->
+## 2. PROBLEM & PURPOSE
+
+### Problem Statement
+Parent packet 015 made `sk-doc/create-benchmark` the single home for benchmark-document templates and standards for four families (MCP promotion, behavior, skill-benchmark, model-benchmark). Two audits show the mission is incomplete: create-benchmark carries zero authoring guidance for Lane A (agent-improvement) and Lane D (non-dev-ai-system), so a reader is silently missing two of six families; the `deep-alignment -> create-benchmark` back-link is absent; and three defects were left carried-over (the packet-identity metadata still reads `016` on a folder renamed to `015`, the parent names a sibling that no longer exists, and every model-benchmark profile's `fixtureDir` points at a directory the underscore-migration renamed away).
+
+### Purpose
+Complete the centralization at the authoring-guidance layer: author the two missing family guides, make all six families discoverable from create-benchmark, finish the bidirectional links, and land the three corrections — without relocating any lane-owned run/scoring contract or code-coupled artifact.
+<!-- /ANCHOR:problem -->
+
+---
+
+<!-- ANCHOR:scope -->
+## 3. SCOPE
+
+### In Scope
+- Two new authoring guides under `create-benchmark/references/`: Lane A (`agent_improvement/agent_improvement_authoring_guide.md`) and Lane D (`non_dev_ai_system/non_dev_ai_system_authoring_guide.md`).
+- Word-neutral `create-benchmark/SKILL.md` edits (the file is at the 5000-word cap): §1 framing, §2 family-table Lane A/D rows + non-goal paragraph, §12 REFERENCES rows; version bump + changelog.
+- Bidirectional links: a create-benchmark back-pointer in `deep-alignment/behavior_benchmark/behavior_benchmark.md`; lane->hub pointers from the Lane A and Lane D in-lane docs.
+- Fix 1 (packet identity 016->015), Fix 2 (dangling sibling), Fix 3 (fixtureDir across 10 profiles + README prose).
+
+### Out of Scope
+- Relocating ANY lane-owned contract, rubric, schema, scorer, runner, or code-coupled template into create-benchmark (operator ruling: contracts stay lane-owned, cross-linked).
+- Any change to run/scoring logic, gates, or the deep-loop hub SKILL.
+- Any edit to the frozen `../review/**` lineage evidence.
+- Any Lane C skill-benchmark report `.md` (renderer-owned) or advisor registry/router re-baseline.
+
+### Files to Change
+
+| File Path | Change Type | Description |
+|-----------|-------------|-------------|
+| `create-benchmark/references/{agent_improvement,non_dev_ai_system}/*_authoring_guide.md` | Create | The two new family authoring guides. |
+| `create-benchmark/SKILL.md`, `create-benchmark/changelog/v1.3.0.0.md` | Modify/Create | Six-family framing + version bump + changelog. |
+| `deep-alignment/behavior_benchmark/behavior_benchmark.md`, Lane A `assets/agent_improvement/README.md`, Lane D `references/non_dev_ai_system/operator_guide.md` | Modify | lane->hub authoring back-pointers. |
+| `deep-improvement/assets/model_benchmark/benchmark_profiles/*.json` (10) | Modify | fixtureDir repoint. |
+| Parent + child metadata and continuity frontmatter | Modify | 016->015 identity + sibling fix. |
+<!-- /ANCHOR:scope -->
+
+---
+
+<!-- ANCHOR:requirements -->
+## 4. REQUIREMENTS
+
+### P0 - Blockers (MUST complete)
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| REQ-001 | Author the Lane A authoring guide, cross-linking (never restating) the 5-dim rubric, evaluator contract, promotion gate, and code-coupled config. | Guide exists; `validate_document.py` 0 issues; grep shows contracts linked, not restated. |
+| REQ-002 | Author the Lane D authoring guide, cross-linking (never relocating) the code-owned schema, 9 templates, and loop contract. | Guide exists; `validate_document.py` 0 issues; code-coupled artifacts linked as in-lane. |
+| REQ-003 | create-benchmark SKILL §2 represents all six families; Lane A/D name their guide; SKILL stays under the word cap. | `package_skill.py create-benchmark --check` PASS; word count <= 5000. |
+| REQ-004 | Repoint every model-benchmark profile `fixtureDir` to the real directory. | All 10 `fixtureDir` resolve; 0 hyphen refs in profile JSONs. |
+| REQ-005 | No lane-owned contract/schema/template relocated; no run/scoring logic changed. | `git diff --stat` clean under run/scoring code, contracts, templates, deep-alignment engine. |
+
+### P1 - Required (complete OR user-approved deferral)
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| REQ-006 | Complete the bidirectional link mesh, including the missing deep-alignment and Lane A/D back-pointers. | `rg create-benchmark deep-alignment` >= 1; each new guide has a lane back-link. |
+| REQ-007 | Live packet-identity metadata reads `015`; parent sibling reference resolves. | No `016` in live metadata/continuity (only frozen review/); sibling resolves. |
+| REQ-008 | Packet passes strict validation. | `validate.sh --strict` Errors:0 on this child; parent recursive no new errors. |
+<!-- /ANCHOR:requirements -->
+
+---
+
+<!-- ANCHOR:success-criteria -->
+## 5. SUCCESS CRITERIA
+
+- **SC-001**: Two new authoring guides exist and pass `validate_document.py` (0 issues).
+- **SC-002**: create-benchmark SKILL §2 covers all six families; `package_skill.py --check` PASS; word count <= cap.
+- **SC-003**: Bidirectional links complete (deep-alignment + Lane A/D back-pointers present and resolving).
+- **SC-004**: No lane-owned relocation; no run/scoring change; all 10 profiles resolve `fixtureDir`.
+- **SC-005**: No `016` in live metadata/continuity; sibling resolves; `validate.sh --strict` Errors:0.
+<!-- /ANCHOR:success-criteria -->
+
+---
+
+<!-- ANCHOR:risks -->
+## 6. RISKS & DEPENDENCIES
+
+| Type | Item | Impact | Mitigation |
+|------|------|--------|------------|
+| Risk | SKILL at the 5000-word cap | New prose could break `package_skill.py --check` | Detail lives in reference guides; SKILL edits measured word-neutral. |
+| Risk | Guides could restate lane contracts | Forks the source of truth | Guides cross-link authorities; a grep pass confirms link-not-copy. |
+| Risk | Metadata regen re-propagates `016` | `generate-context.js` reads packet_id from graph-metadata | Correct graph-metadata first, then regenerate. |
+| Constraint | Frozen `../review/**` and run/scoring code are banned write paths | Some frozen `016` text remains (expected) | Only live metadata/continuity is normalized; report residuals. |
+<!-- /ANCHOR:risks -->
+
+---
+
+<!-- ANCHOR:nfr -->
+## L2: NON-FUNCTIONAL REQUIREMENTS
+
+### Maintainability
+- **NFR-M01**: Every benchmark family has one discoverable authoring home (a guide reachable from create-benchmark §2).
+- **NFR-M02**: Lane-owned contracts stay single-source; create-benchmark links them, never copies.
+
+### Reliability
+- **NFR-R01**: No run/scoring behavior changes; the fixtureDir fix only restores a broken default path.
+<!-- /ANCHOR:nfr -->
+
+---
+
+<!-- ANCHOR:edge-cases -->
+## L2: EDGE CASES
+
+### Path Boundaries
+- Relative back-pointer links from deep-loop lanes into create-benchmark must account for directory depth; each is resolved before finalizing.
+- Frozen `../review/**` evidence retains `016` and is not an active-metadata consumer; it remains unchanged.
+
+### Error Scenarios
+- A guide that restated a rubric would fork the contract; the link-not-copy grep guards against it.
+- A SKILL edit that exceeds the word cap fails `--check`; word count is measured after each edit.
+<!-- /ANCHOR:edge-cases -->
+
+---
+
+<!-- ANCHOR:complexity -->
+## L2: COMPLEXITY ASSESSMENT
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Scope | 12/25 | Two authored guides, three back-pointers, three carried-over corrections. |
+| Risk | 9/25 | Doc-authoring + config path fix; word-cap and link-not-copy are the live risks; no logic change. |
+| Research | 6/20 | Two read-only audits established the move map and blast radius. |
+| **Total** | **27/70** | **Level 2 verification is appropriate.** |
+<!-- /ANCHOR:complexity -->
+
+---
+
+<!-- ANCHOR:questions -->
+## 10. OPEN QUESTIONS
+
+None blocking. Whether the two doc-only Lane A templates (`improvement_charter.md`, `improvement_strategy.md`) should be physically relocated into create-benchmark is a documented, deferred follow-up; this packet keeps them in-lane and guides+links them, consistent with the contracts ruling.
+<!-- /ANCHOR:questions -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/tasks.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks/tasks.md
@@ -1,0 +1,80 @@
+---
+title: "Tasks: Benchmark Authoring Completion and Cross-Links"
+description: "Task breakdown and completion evidence for authoring the Lane A/D guides, completing bidirectional benchmark cross-links, and landing the metadata/sibling/fixtureDir corrections."
+trigger_phrases:
+  - "benchmark authoring completion tasks"
+importance_tier: "important"
+contextType: "implementation"
+_memory:
+  continuity:
+    packet_pointer: "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
+    last_updated_at: "2026-07-13T14:35:28Z"
+    last_updated_by: "claude-code"
+    recent_action: "Tasks authored"
+    next_safe_action: "Run gates and close out"
+    blockers: []
+---
+# Tasks: Benchmark Authoring Completion and Cross-Links
+
+<!-- SPECKIT_TEMPLATE_SOURCE: tasks-core | v2.2 -->
+<!-- SPECKIT_LEVEL: 2 -->
+
+<!-- ANCHOR:notation -->
+## Task Notation
+
+- `[ ]` open, `[x]` done with evidence, `[~]` in progress.
+- Each done task records evidence: command output, file:line, or grep result.
+<!-- /ANCHOR:notation -->
+
+---
+
+<!-- ANCHOR:phase-1 -->
+## Phase 1: Setup
+
+- [x] T1 — Repoint `fixtureDir` `benchmark-fixtures`->`benchmark_fixtures` in all 10 model-benchmark profile JSONs. Evidence: `rg -l benchmark-fixtures benchmark_profiles/*.json` = 0; all 10 `fixtureDir` resolve (`test -d`).
+- [x] T2 — Reconcile hyphen->underscore in `benchmark_profiles/README.md` prose. Evidence: path-segment normalization applied with the JSONs.
+- [x] T3 — Correct live packet identity `016`->`015` in parent+child `graph-metadata.json` and `description.json`. Evidence: `rg 016-benchmark-authoring <015 tree>` returns only frozen `review/**`.
+- [x] T4 — Correct `packet_pointer` and trigger-phrase keys `016`->`015` in live docs. Evidence: grep clean outside `review/**`.
+- [x] T5 — Correct the dangling sibling reference in parent `spec.md`. Evidence: sibling now points at the existing smart-routing packets with a renumber note.
+<!-- /ANCHOR:phase-1 -->
+
+---
+
+<!-- ANCHOR:phase-2 -->
+## Phase 2: Implementation
+
+- [x] T6 — Author Lane A guide `create-benchmark/references/agent_improvement/agent_improvement_authoring_guide.md`. Evidence: `validate_document.py` 0 issues; 241 lines; 22/22 links resolve; contracts linked, not restated.
+- [x] T7 — Author Lane D guide `create-benchmark/references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md`. Evidence: `validate_document.py` 0 issues; 261 lines; code-coupled artifacts linked as in-lane.
+- [x] T8 — SKILL §2 family table: Lane A/D rows name their guide (six families); non-goal paragraph reworded. Evidence: `create-benchmark/SKILL.md` §2 table has 6 family rows; word count `4996` <= cap.
+- [x] T9 — SKILL §1 framing + §12 REFERENCES rows; `version` 1.2.0.0->1.3.0.0; changelog v1.3.0.0. Evidence: `package_skill.py create-benchmark --check` PASS.
+- [x] T10 — Add create-benchmark back-pointer to `deep-alignment/behavior_benchmark/behavior_benchmark.md`. Evidence: `rg create-benchmark deep-alignment` >= 1.
+- [x] T11 — Add Lane A README + Lane D operator-guide pointers to the two new guides. Evidence: each back-pointer path resolves (`ls`).
+- [x] T12 — Verify create-benchmark->lane relative links for A/D resolve. Evidence: guides report 22/22 and 13/13 resolved; `check-markdown-links.cjs` clean of new breaks.
+<!-- /ANCHOR:phase-2 -->
+
+---
+
+<!-- ANCHOR:phase-3 -->
+## Phase 3: Verification
+
+- [x] T13 — `validate.sh --strict` on this child reports Errors:0; parent recursive introduces no new errors. Evidence: see the close-out validation run.
+- [x] T14 — Generated child `description.json` + `graph-metadata.json` (`generate-description.js` + `backfill-graph-metadata.js`); wrote `implementation-summary.md`; added the child 002 row to the parent `spec.md` phase map. Evidence: both JSON files present; parent map has 2 rows.
+<!-- /ANCHOR:phase-3 -->
+
+---
+
+<!-- ANCHOR:completion -->
+## Completion Criteria
+
+All tasks `[x]` with evidence; `spec.md` §5 success criteria met; zero lane-owned contract/schema/template relocated; no run/scoring logic changed.
+<!-- /ANCHOR:completion -->
+
+---
+
+<!-- ANCHOR:cross-refs -->
+## Cross-References
+
+- Parent: `../spec.md` (015 benchmark authoring centralization).
+- Decision record: `./decision-record.md` (ADR-001 amends parent ADR-003; ADR-002 reaffirms ADR-004).
+- Sibling child: `../001-create-benchmark-reorg-and-routing/`.
+<!-- /ANCHOR:cross-refs -->

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/description.json
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/description.json
@@ -16,7 +16,7 @@
     "benchmark",
     "families"
   ],
-  "lastUpdated": "2026-07-13T03:19:37.501Z",
+  "lastUpdated": "2026-07-13T14:31:26.177Z",
   "specId": "016",
   "folderSlug": "benchmark-authoring-centralization",
   "parentChain": [

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/graph-metadata.json
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/graph-metadata.json
@@ -4,7 +4,8 @@
   "spec_folder": "sk-doc/016-benchmark-authoring-centralization",
   "parent_id": null,
   "children_ids": [
-    "sk-doc/016-benchmark-authoring-centralization/001-create-benchmark-reorg-and-routing"
+    "sk-doc/016-benchmark-authoring-centralization/001-create-benchmark-reorg-and-routing",
+    "sk-doc/016-benchmark-authoring-centralization/002-benchmark-authoring-completion-and-crosslinks"
   ],
   "manual": {
     "depends_on": [],
@@ -194,7 +195,7 @@
     ],
     "causal_summary": "Make sk-doc/create-benchmark the single home for benchmark-DOCUMENT templates and authoring standards across all repo benchmark families. Author skill-benchmark storage/README templates and model-benchmark fixture/profile templates plus guides, add a complete family-disambiguation table (Lane A/D marked code-owned), and rewire deep-improvement consumer docs to point at create-benchmark for authoring while run/scoring logic stays in the deep-loop lanes. The Lane C report .md stays renderer-owned.",
     "created_at": "2026-07-12T10:58:43.605Z",
-    "last_save_at": "2026-07-13T04:36:43.554Z",
+    "last_save_at": "2026-07-13T14:32:43.162Z",
     "save_lineage": "graph_only",
     "last_accessed_at": null,
     "source_docs": [
@@ -205,9 +206,9 @@
       "decision-record.md",
       "implementation-summary.md"
     ],
-    "source_fingerprint": "sha256:7329b37ca6aeb53b871dd4ec08dd9cc9a9409bbebb5ab9eabaa086d81ea00eac",
+    "source_fingerprint": "sha256:0f4a329d084c6fc1f6d278b874b69a665d18a4bdabd716ab25893b9f2535944d",
     "source_doc_hashes": {
-      "spec.md": "80ff2392e3b572957d291e655af8d5518f28217ec212ac9b84aa2877aa710187",
+      "spec.md": "235f31262749246d34d35535ad37af2d03a511e7e592a2d22c39560679784cea",
       "plan.md": "1bc303e4d4c3a00226a1cc641e1546a3deed2ef97ed740be14abe04739e67966",
       "tasks.md": "be65a06461782483df9357814e110f03b884258734c0069435eab66c03c2186b",
       "checklist.md": "20eb024c13e52d7e0f83a274628eee5cc5837cc06bd02ae70d804790df91ffb3",

--- a/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/spec.md
+++ b/.opencode/specs/sk-doc/016-benchmark-authoring-centralization/spec.md
@@ -108,11 +108,12 @@ None blocking. Whether to CI-wire `package_skill.py` is a documented optional fo
 
 ## 8. PHASE DOCUMENTATION MAP
 
-> This packet is a phase parent: the child phase below carries the family-oriented resource grouping and routing-coverage work. Each child validates independently; run `validate.sh --recursive` on this parent to validate the set.
+> This packet is a phase parent: the child phases below carry the family-oriented resource grouping and routing-coverage work, plus the authoring-guide completion and cross-link corrections. Each child validates independently; run `validate.sh --recursive` on this parent to validate the set.
 
 | Phase | Folder | Focus | Status |
 |-------|--------|-------|--------|
 | 001 | `001-create-benchmark-reorg-and-routing/` | Group create-benchmark resources into per-family subfolders and add durable behavior/skill/model/fixture routing vocabulary | Complete |
+| 002 | `002-benchmark-authoring-completion-and-crosslinks/` | Author the Lane A/D authoring guides, complete the create-benchmark ↔ deep-loop cross-links, and land the fixtureDir/metadata/sibling corrections | Complete |
 
 ### Phase Transition Rules
 


### PR DESCRIPTION
## Summary

Completes `sk-doc/create-benchmark` as the single authoring home for **all six** benchmark families, and lands three carried-over corrections. Nothing lane-owned is relocated and no run/scoring logic changes (operator ruling: contracts stay lane-owned, cross-linked).

**New authoring guides** (cross-link the lane authorities, never restate them):
- Lane A agent-improvement — `references/agent_improvement/agent_improvement_authoring_guide.md`
- Lane D non-dev-ai-system — `references/non_dev_ai_system/non_dev_ai_system_authoring_guide.md`

**SKILL.md** six-family framing, `v1.2.0.0 → v1.3.0.0` + changelog (word-neutral, `package_skill --check` PASS 4997/5000).

**Bidirectional back-pointers** into create-benchmark from `deep-alignment/behavior_benchmark/behavior_benchmark.md`, `deep-improvement/assets/agent_improvement/README.md`, and `.../references/non_dev_ai_system/operator_guide.md`.

**Carried-over fixes:**
- `fix`: repoint `fixtureDir` `benchmark-fixtures → benchmark_fixtures` across all 10 model-benchmark profiles (the underscore migration left every profile's default fixture path dangling).
- New Level-2 child `002-benchmark-authoring-completion-and-crosslinks` under `016-benchmark-authoring-centralization`; registered in the parent phase map; parent + child metadata regenerated.

## Why 016 (not 015)

This work was originally staged under a `016→015` folder rename. Verification against HEAD **and** origin showed the packet is canonically `016-benchmark-authoring-centralization` on both — the rename was never adopted. This PR re-homes the work under the correct **016** identity.

## Concurrent-session note

`SKILL.md v1.3.0.0` is identical to a copy a concurrent session already committed to the shared local branch (not yet on origin). Since both make the byte-identical `v1.2.0.0 → v1.3.0.0` change, they 3-way merge cleanly regardless of ordering.

## Validation
- `validate.sh --strict` child 002: **Errors:0 Warnings:0 PASSED**
- `validate.sh --strict --recursive` parent: **Errors:0** (4 pre-existing phase-parent-policy warnings)
- `validate_document.py`: **0 issues** on both guides + changelog
- `package_skill.py --check` create-benchmark: **PASS**
- markdown link check: **0 broken links** originate in the authored files

🤖 Generated with [Claude Code](https://claude.com/claude-code)