### PR TITLE
fix(cli-external-orchestration): make the stdin-redirect guard machine-checkable everywhere

### DIFF
--- a/.opencode/skills/cli-external-orchestration/cli-claude-code/SKILL.md
+++ b/.opencode/skills/cli-external-orchestration/cli-claude-code/SKILL.md
@@ -4,6 +4,10 @@ description: "Claude Code CLI executor for Anthropic-backed reasoning, edits, re
 allowed-tools: [Bash, Read, Glob, Grep]
 version: 1.4.0.0
 hard_rules:
+  - id: stdin-redirect-required
+    check: stdin-redirect-required
+    message: "Any non-interactive dispatch MUST close/redirect stdin (`</dev/null`). Omitting it can hang with zero output, which is indistinguishable from a slow model."
+    severity: warn
   - id: non-interactive-permission-mode-risk
     check: non-interactive-permission-mode-risk
     message: "Non-interactive `claude -p` with acceptEdits + no TTY + a Bash-heavy prompt can deadlock on an unanswerable shell-permission prompt; run it sandboxed with `--dangerously-skip-permissions` or ensure the prompt needs no shell approval."

--- a/.opencode/skills/cli-external-orchestration/cli-codex/SKILL.md
+++ b/.opencode/skills/cli-external-orchestration/cli-codex/SKILL.md
@@ -4,6 +4,10 @@ description: "Codex CLI executor for OpenAI-backed coding, repo analysis, PR rev
 allowed-tools: [Bash, Read, Glob, Grep]
 version: 1.8.0.0
 hard_rules:
+  - id: stdin-redirect-required
+    check: stdin-redirect-required
+    message: "Any non-interactive `codex exec` MUST close/redirect stdin (`</dev/null`) — not only inside a read loop. Omitting it can hang with zero output, which is indistinguishable from a slow model."
+    severity: warn
   - id: codex-availability-required
     check: command-v-codex-required
     message: "Run `command -v codex` before every dispatch; if it fails, refuse the route without constructing or launching a command."
@@ -269,7 +273,7 @@ The full flag glossary, sandbox modes, unique capabilities (`/review`, `--search
 3. Use `--sandbox read-only` for review/analysis/research; `--sandbox workspace-write` for code generation/file modification — `codex exec` defaults to `read-only`, so omitting it causes silent no-op on edit tasks. For unattended approval, put top-level `-a never` before `exec` or set `-c approval_policy=never`.
 4. Validate Codex-generated code (XSS, injection, eval, syntax checks via `node --check`, `tsc --noEmit`, etc.) before applying.
 5. Capture stderr (`2>&1`) so rate-limit messages and errors surface.
-6. **Redirect codex stdin from `/dev/null`** when dispatching in a `while read` loop. Pattern: `codex exec "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Without `</dev/null`, the backgrounded codex process inherits the loop's stdin (the file after `done < input.jsonl`) and silently consumes the remaining lines — the loop exits after 3-6 iterations with no error. See `references/integration-patterns.md#background-execution` → "Silent Stdin Consumption".
+6. **Redirect codex stdin from `/dev/null` on EVERY non-interactive dispatch** — not only inside a `while read` loop, which is the condition this rule used to name and the reason it was skipped. Pattern: `codex exec "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Without `</dev/null`, the backgrounded codex process inherits the loop's stdin (the file after `done < input.jsonl`) and silently consumes the remaining lines — the loop exits after 3-6 iterations with no error. See `references/integration-patterns.md#background-execution` → "Silent Stdin Consumption".
 7. **Specify model + effort + service tier explicitly** — never rely on caller environment. Default: `--model gpt-5.5 -c model_reasoning_effort="medium" -c service_tier="fast"`. Honor user overrides verbatim. Use `high`/`xhigh` for reasoning-heavy tasks (architecture, security, deep planning).
 8. Route to the appropriate `-p <profile>` when the task matches a specialization (see Section 3 routing table); use `codex exec review` (built-in subcommand) for git diff reviews.
 9. **Pass the spec folder to the delegated agent** in the prompt: if the calling AI has an active Gate-3 spec folder, include `Spec folder: <path> (pre-approved, skip Gate 3)`. If none, ASK the user before delegating — the delegated agent cannot answer Gate 3 in non-interactive mode.

--- a/.opencode/skills/cli-external-orchestration/cli-cursor/SKILL.md
+++ b/.opencode/skills/cli-external-orchestration/cli-cursor/SKILL.md
@@ -4,6 +4,10 @@ description: "Cursor CLI executor for cursor-agent-backed coding, plan/ask read-
 allowed-tools: [Bash, Read, Glob, Grep]
 version: 1.4.1.0
 hard_rules:
+  - id: stdin-redirect-required
+    check: stdin-redirect-required
+    message: "Any non-interactive `cursor-agent -p` MUST close/redirect stdin (`</dev/null`) — not only inside a read loop. Omitting it can hang with zero output, which is indistinguishable from a slow model."
+    severity: warn
   - id: cursor-availability-required
     check: command-v-cursor-agent-required
     message: "Run `command -v cursor-agent` before every dispatch; if it fails, refuse the route without constructing or launching a command."
@@ -299,7 +303,7 @@ The full flag glossary, hook contract, shared-config surface, and troubleshootin
 3. Use `--mode plan` or `--mode ask` for read-only exploration/analysis/research; use the default agent mode with `--auto-review` or `--force` for code generation/file modification.
 4. Validate Cursor-generated code (XSS, injection, eval, syntax checks via `node --check`, `tsc --noEmit`, etc.) before applying.
 5. Capture stderr (`2>&1`) so errors surface; check output TEXT for auth/availability failures, never the exit code (always `0`).
-6. **Redirect cursor-agent stdin from `/dev/null`** when dispatching in a `while read` loop, mirroring the family-wide convention: `cursor-agent -p "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Live-verified: a real `cursor-agent -p ... </dev/null` dispatch completes normally with no hang.
+6. **Redirect cursor-agent stdin from `/dev/null` on EVERY non-interactive dispatch** — not only inside a `while read` loop, which is the condition this rule used to name and the reason it was skipped, mirroring the family-wide convention: `cursor-agent -p "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Live-verified: a real `cursor-agent -p ... </dev/null` dispatch completes normally with no hang.
 7. **Specify model and approval mode explicitly** — never rely on caller environment. Default: `--model composer-2.5 --auto-review --sandbox enabled`. Honor user overrides verbatim, but ONLY within the enforced allowlist (§3 Model Selection) — never `auto`, never a model outside the 21 allowed ids.
 8. Route to `--mode plan`/`--mode ask`/default agent per the task type (see Section 3 routing table).
 9. **Pass the spec folder to the delegated agent** in the prompt: if the calling AI has an active Gate-3 spec folder, include `Spec folder: <path> (pre-approved, skip Gate 3)`. If none, ASK the user before delegating — the delegated agent cannot answer Gate 3 in `--force`/non-interactive mode.

--- a/.opencode/skills/cli-external-orchestration/cli-devin/SKILL.md
+++ b/.opencode/skills/cli-external-orchestration/cli-devin/SKILL.md
@@ -4,6 +4,10 @@ description: "Devin CLI executor for Cognition-backed coding, cloud handoff, sub
 allowed-tools: [Bash, Read, Glob, Grep]
 version: 1.4.1.0
 hard_rules:
+  - id: stdin-redirect-required
+    check: stdin-redirect-required
+    message: "Any non-interactive `devin -p` MUST close/redirect stdin (`</dev/null`) — not only inside a read loop. Omitting it can hang with zero output, which is indistinguishable from a slow model."
+    severity: warn
   - id: devin-availability-required
     check: command-v-devin-required
     message: "Run `command -v devin` before every dispatch; if it fails, refuse the route without constructing or launching a command."
@@ -350,7 +354,7 @@ Then `auto`/`accept-edits` auto-approve exactly those MCP tools; reserve `danger
 3. Use `--permission-mode auto` for review/analysis/research; `--permission-mode dangerous` for code generation and file modification — `devin -p` itself defaults to `auto`, so omitting the flag causes a silent no-op on edit tasks. Prefer `dangerous` over `accept-edits` for any task that must read files or run its own verification; `accept-edits` refuses those calls and the dispatch fails silently.
 4. Validate Devin-generated code (XSS, injection, eval, syntax checks via `node --check`, `tsc --noEmit`, etc.) before applying.
 5. Capture stderr (`2>&1`) so rate-limit messages and errors surface.
-6. **Redirect devin stdin from `/dev/null`** when dispatching in a `while read` loop. Pattern: `devin -p -- "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Without `</dev/null`, the backgrounded devin process inherits the loop's stdin and silently consumes the remaining lines. See `references/integration-patterns.md#background-execution` → "Silent Stdin Consumption".
+6. **Redirect devin stdin from `/dev/null` on EVERY non-interactive dispatch** — not only inside a `while read` loop, which is the condition this rule used to name and the reason it was skipped. Pattern: `devin -p -- "$PROMPT" > "$LOG" 2>&1 </dev/null &`. Without `</dev/null`, the backgrounded devin process inherits the loop's stdin and silently consumes the remaining lines. See `references/integration-patterns.md#background-execution` → "Silent Stdin Consumption".
 7. **Specify model + permission mode explicitly** — never rely on caller environment. Default: `--model swe --permission-mode dangerous`. Honor user overrides verbatim. Use `deepseek-v4-pro-max` or `gpt-5-6-luna-max` for reasoning-heavy tasks (architecture, security, deep planning).
 8. Route to the appropriate subagent profile when the task matches a specialization (see Section 3 routing table); use `subagent_explore` for read-only research, `subagent_general` for code changes.
 9. **Pass the spec folder to the delegated agent** in the prompt: if the calling AI has an active Gate-3 spec folder, include `Spec folder: <path> (pre-approved, skip Gate 3)`. If none, ASK the user before delegating — the delegated agent cannot answer Gate 3 in non-interactive `-p` mode.

--- a/.opencode/skills/cli-external-orchestration/cli-pi/SKILL.md
+++ b/.opencode/skills/cli-external-orchestration/cli-pi/SKILL.md
@@ -4,6 +4,10 @@ description: "Pi CLI executor for guarded headless coding, JSON/RPC integration,
 allowed-tools: [Bash, Read, Glob, Grep]
 version: 1.3.0.0
 hard_rules:
+  - id: stdin-redirect-required
+    check: stdin-redirect-required
+    message: "Any non-interactive `pi -p` MUST close/redirect stdin (`</dev/null`) — omitting it hangs indefinitely with ZERO output, which reads as a slow model rather than a deadlock."
+    severity: warn
   - id: pi-availability-required
     check: command-v-pi-required
     message: "Run command -v pi before every dispatch; if it fails, refuse the route without constructing or launching a command."
@@ -216,6 +220,12 @@ The caller remains responsible for task scope, files, acceptance criteria, and v
 
 The full flag glossary and pinned-contract citations are in the ALWAYS-loaded [cli-reference.md](./references/cli-reference.md). Gotchas that silently break a dispatch and must be honored at routing time:
 
+- **Redirect stdin on every non-interactive dispatch: `</dev/null`.** Without it `pi -p` inherits the
+  parent terminal's stdin and hangs indefinitely, emitting **nothing at all** — not a partial answer,
+  not an error. Because print mode buffers until completion, an empty log is also what a working
+  dispatch looks like mid-run, so the deadlock is indistinguishable from a slow model and has been
+  mistaken for one for over an hour. The sibling `cli-opencode` packet carries the same rule for
+  `opencode run`; it applies here for exactly the same reason.
 - **`--offline` is required for any automated or CI dispatch.** `pi --verbose` without `--offline` hung for over two minutes with no reachable network path in the pinned contract's live probe. Any non-interactive dispatch through this packet must pass `--offline` explicitly rather than rely on a fast failure.
 - **The exit code is never an availability or auth signal.** An identical unauthenticated `pi -p` dispatch returned exit `0` on the first run and exit `1` on every subsequent run in the pinned contract. Every guard in this packet checks output text (`No API key found...`), never exit code.
 - **An invalid `.pi/extensions/*.ts` fails the whole session, not just that extension.** The pinned contract confirmed Pi validates extensions must export a factory function; a broken one blocks the entire dispatch with `Extension does not export a valid factory function` rather than skipping it with a warning.


### PR DESCRIPTION
## What it cost

A non-interactive dispatch that inherits the parent terminal's stdin hangs and emits **nothing at all** — not a partial answer, not an error. Print mode buffers until completion, so an empty log is *also* what a healthy dispatch looks like mid-run.

The deadlock is therefore indistinguishable from a slow model. In this session it was mistaken for one for **over an hour**, across two separate `pi` dispatches, before the cause was found.

## The gap

| Packet | Before | After |
|---|---|---|
| `cli-opencode` | rule + prose | unchanged |
| `cli-pi` | **nothing** — where it bit | rule + prose |
| `cli-claude-code` | **nothing** | rule |
| `cli-codex` | prose only | rule + broadened prose |
| `cli-cursor` | prose only | rule + broadened prose |
| `cli-devin` | prose only | rule + broadened prose |

## The wording that let it through

The three prose-only packets scoped the rule to a condition that doesn't hold:

> **Redirect codex stdin from `/dev/null`** when dispatching in a `while read` loop

The hang has **no such precondition** — it was reproduced here with no loop involved. The narrower wording read as inapplicable and was skipped. That condition is removed; the rule now says *every* non-interactive dispatch, and says why the old wording failed.

## Evidence

Same route, model and tier — the only difference is the redirect:

```
pi ... -p "Reply with exactly: OK"                    → HANGING (0 bytes)
pi ... -p "Reply with exactly: OK" < /dev/null        → RETURNED 187 bytes: OK
opencode run ... "Reply with exactly: OK"             → HANGING (0 bytes)
opencode run ... "Reply with exactly: OK" </dev/null  → RETURNED 43 bytes: OK
```

## Verification

- All six `SKILL.md` frontmatter blocks parse, each carrying `stdin-redirect-required`
- `check-markdown-links.cjs` — 0 broken
- `ci-skill-root-metadata.cjs` — `checked=14 passed=14 failed=0`
- The packet's own prompt-card guard passes on all six

## Note on the routing gate

The pre-push routing gate reports `cli-external-orchestration` as `stale-manifest` and `compiled-route-sync --check` fails to resolve that hub. **This is pre-existing, not caused by this change** — verified by stashing these edits and reproducing the identical failure on clean `origin/main`. `mint` returns `already-exists` and `refresh` returns `hub-mismatch`, both with a null `currentPolicyHash`, so the hub needs separate attention from whoever owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX229k9YnEUGpjpg42ShKV